### PR TITLE
Feature introduce assets client

### DIFF
--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary.Tests/ClientQueryFixture.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary.Tests/ClientQueryFixture.cs
@@ -20,6 +20,14 @@ namespace Squidex.ClientLibrary.Tests
             {
                 var items = await Client.GetAsync();
 
+                if (items.Total > 10)
+                {
+                    foreach (var item in items.Items)
+                    {
+                        await Client.DeleteAsync(item);
+                    }
+                }
+
                 if (items.Total == 0)
                 {
                     for (var i = 10; i > 0; i--)

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary.Tests/ClientQueryTests.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary.Tests/ClientQueryTests.cs
@@ -25,7 +25,7 @@ namespace Squidex.ClientLibrary.Tests
         {
             var items = await Fixture.Client.GetAsync();
 
-            AssertItems(items, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+            AssertItems(items, 10, new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
         }
 
         [Fact]
@@ -33,7 +33,7 @@ namespace Squidex.ClientLibrary.Tests
         {
             var items = await Fixture.Client.GetAsync(skip: 5);
 
-            AssertItems(items, 6, 7, 8, 9, 10);
+            AssertItems(items, 10, new[] { 6, 7, 8, 9, 10 });
         }
 
         [Fact]
@@ -41,7 +41,7 @@ namespace Squidex.ClientLibrary.Tests
         {
             var items = await Fixture.Client.GetAsync(skip: 2, top: 5);
 
-            AssertItems(items, 3, 4, 5, 6, 7);
+            AssertItems(items, 10, new[] { 3, 4, 5, 6, 7 });
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace Squidex.ClientLibrary.Tests
         {
             var items = await Fixture.Client.GetAsync(skip: 2, top: 5, orderBy: "data/value/iv desc");
 
-            AssertItems(items, 8, 7, 6, 5, 4);
+            AssertItems(items, 10, new[] { 8, 7, 6, 5, 4 });
         }
 
         [Fact]
@@ -57,16 +57,16 @@ namespace Squidex.ClientLibrary.Tests
         {
             var items = await Fixture.Client.GetAsync(filter: "data/value/iv gt 3 and data/value/iv lt 7");
 
-            AssertItems(items, 3, 4, 5, 6);
+            AssertItems(items, 3, new[] { 4, 5, 6 });
         }
 
-        private void AssertItems(SquidexEntities<TestEntity, TestEntityData> entities, params int[] expected)
+        private void AssertItems(SquidexEntities<TestEntity, TestEntityData> entities, int[] expected)
         {
             Assert.Equal(10, entities.Total);
             Assert.Equal(expected, entities.Items.Select(x => x.Data.Value).ToArray());
         }
 
-        private void AssertItems(SquidexEntities<TestEntity, TestEntityData> entities, int total, params int[] expected)
+        private void AssertItems(SquidexEntities<TestEntity, TestEntityData> entities, int total, int[] expected)
         {
             Assert.Equal(total, entities.Total);
             Assert.Equal(expected, entities.Items.Select(x => x.Data.Value).ToArray());

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary.Tests/Squidex.ClientLibrary.Tests.csproj
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary.Tests/Squidex.ClientLibrary.Tests.csproj
@@ -14,10 +14,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
-  <ImportGroup>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-  </ImportGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Squidex.ClientLibrary\Squidex.ClientLibrary.csproj" />
   </ItemGroup>

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/Asset.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/Asset.cs
@@ -1,0 +1,28 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System;
+
+namespace Squidex.ClientLibrary
+{
+    public class Asset
+    {
+        public string Id { get; set; }
+        public string FileName { get; set; }
+        public string MimeType { get; set; }
+        public int FileSize { get; set; }
+        public int FileVersion { get; set; }
+        public bool IsImage { get; set; }
+        public int PixelWidth { get; set; }
+        public int PixelHeight { get; set; }
+        public DateTimeOffset Created { get; set; }
+        public string CreatedBy { get; set; }
+        public DateTimeOffset LastModified { get; set; }
+        public string LastModifiedBy { get; set; }
+        public int Version { get; set; }
+    }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/AssetEntities.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/AssetEntities.cs
@@ -9,12 +9,9 @@ using System.Collections.Generic;
 
 namespace Squidex.ClientLibrary
 {
-    public sealed class SquidexEntities<TEntity, TData>
-        where TEntity : SquidexEntityBase<TData>
-        where TData : class, new()
+    public class AssetEntities
     {
-        public List<TEntity> Items { get; } = new List<TEntity>();
-
+        public IList<Asset> Items { get; } = new List<Asset>();
         public long Total { get; set; }
     }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexAssetClient.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexAssetClient.cs
@@ -1,0 +1,151 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+namespace Squidex.ClientLibrary
+{
+    public sealed class SquidexAssetClient : SquidexClientBase
+    {
+        public SquidexAssetClient(Uri serviceUrl, string applicationName, string schemaName, IAuthenticator authenticator)
+            : base(serviceUrl, applicationName, schemaName, authenticator)
+        {
+        }
+
+        public async Task<Asset> UpdateAssetContentAsync(string id, string contentName, string contentMimeType, byte[] contentBytes)
+        {
+            Guard.NotNullOrEmpty(id, nameof(id));
+            Guard.NotNullOrEmpty(contentName, nameof(contentName));
+            Guard.NotNullOrEmpty(contentMimeType, nameof(contentMimeType));
+            Guard.NotNull(contentBytes, nameof(contentBytes));
+
+            var streamContent = new ByteArrayContent(contentBytes);
+            streamContent.Headers.ContentType = new MediaTypeHeaderValue(contentMimeType);
+
+            var requestContent = new MultipartFormDataContent
+            {
+                { streamContent, "file", contentName }
+            };
+
+            var response = await RequestAsync(HttpMethod.Put, SquidexUriKind.AppAssets, $"{id}/content", requestContent);
+            return await response.Content.ReadAsJsonAsync<Asset>();
+        }
+
+        public async Task DeleteAssetAsync(string id)
+        {
+            Guard.NotNullOrEmpty(id, nameof(id));
+
+            await RequestAsync(HttpMethod.Delete, SquidexUriKind.AppAssets, id);
+        }
+
+        public async Task<Asset> CreateAssetAsync(string contentName, string contentMimeType, byte[] contentBytes)
+        {
+            Guard.NotNullOrEmpty(contentName, nameof(contentName));
+            Guard.NotNullOrEmpty(contentMimeType, nameof(contentMimeType));
+            Guard.NotNull(contentBytes, nameof(contentBytes));
+
+            var streamContent = new ByteArrayContent(contentBytes);
+            streamContent.Headers.ContentType = new MediaTypeHeaderValue(contentMimeType);
+
+            var requestContent = new MultipartFormDataContent
+            {
+                { streamContent, "file", contentName }
+            };
+
+            var response = await RequestAsync(HttpMethod.Post, SquidexUriKind.AppAssets, content: requestContent);
+            return await response.Content.ReadAsJsonAsync<Asset>();
+        }
+
+        public async Task<Stream> GetAssetContentAsync(string id, int? version = null, int? width = null, int? height = null, string mode = null)
+        {
+            Guard.NotNullOrEmpty(id, nameof(id));
+
+            var queries = new List<string> { $"app={ApplicationName}" };
+
+            if (version.HasValue)
+            {
+                queries.Add($"version={version.Value}");
+            }
+
+            if (width.HasValue)
+            {
+                queries.Add($"width={width.Value}");
+            }
+
+            if (height.HasValue)
+            {
+                queries.Add($"height={height.Value}");
+            }
+
+            if (!string.IsNullOrEmpty(mode))
+            {
+                queries.Add($"mode={mode}");
+            }
+
+            var queryString = string.Join("&", queries);
+            if (!string.IsNullOrWhiteSpace(queryString))
+            {
+                queryString = "?" + queryString;
+            }
+
+            var response = await RequestAsync(HttpMethod.Get, SquidexUriKind.Assets, $"{id}/{queryString}");
+            return await response.Content.ReadAsStreamAsync();
+        }
+
+        public async Task<Asset> GetAssetAsync(string id)
+        {
+            Guard.NotNullOrEmpty(id, nameof(id));
+
+            var response = await RequestAsync(HttpMethod.Get, SquidexUriKind.AppAssets, id);
+            return await response.Content.ReadAsJsonAsync<Asset>();
+        }
+
+        public async Task<AssetEntities> GetAssetsAsync(string query = null, string mimeTypes = null, string ids = null, int? skip = null, int? take = null)
+        {
+            var queries = new List<string>();
+
+            if (skip.HasValue)
+            {
+                queries.Add($"$skip={skip.Value}");
+            }
+
+            if (take.HasValue)
+            {
+                queries.Add($"take={take.Value}");
+            }
+
+            if (!string.IsNullOrEmpty(query))
+            {
+                queries.Add($"$query={query}");
+            }
+
+            if (!string.IsNullOrEmpty(mimeTypes))
+            {
+                queries.Add($"mimeTypes={mimeTypes}");
+            }
+
+            if (!string.IsNullOrEmpty(ids))
+            {
+                queries.Add($"ids={ids}");
+            }
+
+            var queryString = string.Join("&", queries);
+            if (!string.IsNullOrWhiteSpace(queryString))
+            {
+                queryString = "?" + queryString;
+            }
+
+            var response = await RequestAsync(HttpMethod.Get, SquidexUriKind.AppAssets, query);
+            return await response.Content.ReadAsJsonAsync<AssetEntities>();
+        }
+    }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientBase.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientBase.cs
@@ -1,0 +1,126 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+namespace Squidex.ClientLibrary
+{
+    public abstract class SquidexClientBase
+    {
+        protected string ApplicationName { get; }
+        protected Uri ServiceUrl { get; }
+        protected string SchemaName { get; }
+        protected IAuthenticator Authenticator { get; }
+
+        protected SquidexClientBase(Uri serviceUrl, string applicationName, string schemaName, IAuthenticator authenticator)
+        {
+            Guard.NotNull(serviceUrl, nameof(serviceUrl));
+            Guard.NotNull(authenticator, nameof(authenticator));
+            Guard.NotNullOrEmpty(applicationName, nameof(applicationName));
+
+            ServiceUrl = serviceUrl;
+            SchemaName = schemaName;
+            Authenticator = authenticator;
+            ApplicationName = applicationName;
+        }
+
+        protected string BuildSquidexUri(SquidexUriKind uriKind, string path = "")
+        {
+            switch (uriKind)
+            {
+                case SquidexUriKind.Content:
+                    return $"api/content/{ApplicationName}/{SchemaName}/{path}";
+                case SquidexUriKind.Assets:
+                    return $"api/assets/{path}";
+                case SquidexUriKind.AppAssets:
+                    return $"api/apps/{ApplicationName}/assets/{path}";
+                default:
+                    throw new NotSupportedException($"The uri kind '{uriKind}' is not supported.");
+            }
+        }
+
+        protected async Task<HttpResponseMessage> RequestAsync(HttpMethod method, SquidexUriKind uriKind, string path = "", HttpContent content = null, QueryContext context = null)
+        {
+            var uri = new Uri(ServiceUrl, BuildSquidexUri(uriKind, path));
+
+            var requestToken = await Authenticator.GetBearerTokenAsync();
+            var request = BuildRequest(method, content, uri, requestToken);
+
+            if (context != null)
+            {
+                if (context.IsFlatten)
+                {
+                    request.Headers.TryAddWithoutValidation("X-Flatten", "true");
+                }
+
+                if (context.Languages != null)
+                {
+                    var languages = string.Join(", ", context.Languages.Where(x => !string.IsNullOrWhiteSpace(x)));
+
+                    if (!string.IsNullOrWhiteSpace(languages))
+                    {
+                        request.Headers.TryAddWithoutValidation("X-Languages", languages);
+                    }
+                }
+            }
+
+            var response = await SquidexHttpClient.Instance.SendAsync(request);
+
+            await EnsureResponseIsValidAsync(response, requestToken);
+
+            return response;
+        }
+
+        protected static HttpRequestMessage BuildRequest(HttpMethod method, HttpContent content, Uri uri, string requestToken)
+        {
+            var request = new HttpRequestMessage(method, uri);
+
+            if (content != null)
+            {
+                request.Content = content;
+            }
+
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", requestToken);
+
+            return request;
+        }
+
+        protected async Task EnsureResponseIsValidAsync(HttpResponseMessage response, string token)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                if (response.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    await Authenticator.RemoveTokenAsync(token);
+                }
+
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    throw new SquidexException("The app, schema or entity does not exist.");
+                }
+
+                var message = await response.Content.ReadAsStringAsync();
+
+                if (string.IsNullOrWhiteSpace(message))
+                {
+                    message = "Squidex API failed with internal error.";
+                }
+                else
+                {
+                    message = $"Squidex Request failed: {message}";
+                }
+
+                throw new SquidexException(message);
+            }
+        }
+    }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientManager.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientManager.cs
@@ -59,8 +59,17 @@ namespace Squidex.ClientLibrary
                 options.ClientSecret);
         }
 
-        public SquidexClient<TEntity, TData> GetClient<TEntity, TData>(string schemaName) where TData : class, new() where TEntity : SquidexEntityBase<TData>
+        public SquidexAssetClient GetAssetClient()
         {
+            return new SquidexAssetClient(serviceUrl, applicationName, string.Empty, authenticator);
+        }
+
+        public SquidexClient<TEntity, TData> GetClient<TEntity, TData>(string schemaName)
+            where TEntity : SquidexEntityBase<TData>
+            where TData : class, new()
+        {
+            Guard.NotNullOrEmpty(schemaName, nameof(schemaName));
+
             return new SquidexClient<TEntity, TData>(serviceUrl, applicationName, schemaName, authenticator);
         }
     }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexUriKind.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexUriKind.cs
@@ -5,16 +5,12 @@
 //  All rights reserved. Licensed under the MIT license.
 // ==========================================================================
 
-using System.Collections.Generic;
-
 namespace Squidex.ClientLibrary
 {
-    public sealed class SquidexEntities<TEntity, TData>
-        where TEntity : SquidexEntityBase<TData>
-        where TData : class, new()
+    public enum SquidexUriKind
     {
-        public List<TEntity> Items { get; } = new List<TEntity>();
-
-        public long Total { get; set; }
+        Content,
+        Assets,
+        AppAssets
     }
 }


### PR DESCRIPTION
Migrated our code base to access and update Squidex assets to provided ClientLibrary.

Done changes:
1) Opening in VS2017 was not possible for me until I removed the <DotNetCliToolReference /> in project file. Running the provided tests resulted in failures due different overload picked as expected/wanted.

2) Define SquidexAssetClient similar to current SquidexClient. For that moved request making code to own base class for both clients and extend it a bit to allow URI building variation.