### PR TITLE
Moved HttpClient creation to the manager and made HttpClientHandler per HttpClient.

### DIFF
--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexAssetClient.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexAssetClient.cs
@@ -19,8 +19,8 @@ namespace Squidex.ClientLibrary
 {
     public sealed class SquidexAssetClient : SquidexClientBase
     {
-        public SquidexAssetClient(Uri serviceUrl, string applicationName, string schemaName, HttpMessageHandler messageHandler)
-            : base(serviceUrl, applicationName, schemaName, messageHandler)
+        public SquidexAssetClient(Uri serviceUrl, string applicationName, string schemaName, Func<HttpClient> httpClientFactory)
+            : base(serviceUrl, applicationName, schemaName, httpClientFactory)
         {
         }
 

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexAssetClient.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexAssetClient.cs
@@ -19,8 +19,8 @@ namespace Squidex.ClientLibrary
 {
     public sealed class SquidexAssetClient : SquidexClientBase
     {
-        public SquidexAssetClient(Uri serviceUrl, string applicationName, string schemaName, Func<HttpClient> httpClientFactory)
-            : base(serviceUrl, applicationName, schemaName, httpClientFactory)
+        public SquidexAssetClient(Uri serviceUrl, string applicationName, IAuthenticator authenticator)
+            : base(serviceUrl, applicationName, authenticator)
         {
         }
 

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClient.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClient.cs
@@ -20,8 +20,8 @@ namespace Squidex.ClientLibrary
     {
         public string SchemaName { get; }
 
-        public SquidexClient(Uri serviceUrl, string applicationName, string schemaName, HttpMessageHandler messageHandler)
-            : base(serviceUrl, applicationName, schemaName, messageHandler)
+        public SquidexClient(Uri serviceUrl, string applicationName, string schemaName, Func<HttpClient> httpClientFactory)
+            : base(serviceUrl, applicationName, schemaName, httpClientFactory)
         {
             Guard.NotNullOrEmpty(schemaName, nameof(schemaName));
 

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClient.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClient.cs
@@ -20,8 +20,8 @@ namespace Squidex.ClientLibrary
     {
         public string SchemaName { get; }
 
-        public SquidexClient(Uri serviceUrl, string applicationName, string schemaName, Func<HttpClient> httpClientFactory)
-            : base(serviceUrl, applicationName, schemaName, httpClientFactory)
+        public SquidexClient(Uri serviceUrl, string applicationName, string schemaName, IAuthenticator authenticator)
+            : base(serviceUrl, applicationName, authenticator)
         {
             Guard.NotNullOrEmpty(schemaName, nameof(schemaName));
 

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientBase.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientBase.cs
@@ -14,28 +14,26 @@ namespace Squidex.ClientLibrary
 {
     public abstract class SquidexClientBase
     {
-        private readonly HttpMessageHandler messageHandler;
+        protected Func<HttpClient> HttpClientFactory { get; }
 
         protected Uri ServiceUrl { get; }
 
         protected string ApplicationName { get; }
 
-        protected SquidexClientBase(Uri serviceUrl, string applicationName, string schemaName, HttpMessageHandler messageHandler)
+        protected SquidexClientBase(Uri serviceUrl, string applicationName, string schemaName, Func<HttpClient> httpClientFactory)
         {
             Guard.NotNull(serviceUrl, nameof(serviceUrl));
-            Guard.NotNull(messageHandler, nameof(messageHandler));
+            Guard.NotNull(httpClientFactory, nameof(httpClientFactory));
             Guard.NotNullOrEmpty(applicationName, nameof(applicationName));
 
-            this.messageHandler = messageHandler;
-
+            HttpClientFactory = httpClientFactory;
             ApplicationName = applicationName;
-
             ServiceUrl = serviceUrl;
         }
 
         protected async Task<HttpResponseMessage> RequestAsync(HttpMethod method, string path, HttpContent content = null, QueryContext context = null)
         {
-            using (var httpClient = new HttpClient(messageHandler))
+            using (var httpClient = HttpClientFactory())
             {
                 var uri = new Uri(ServiceUrl, path);
 

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientBase.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientBase.cs
@@ -10,41 +10,39 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 
+using Squidex.ClientLibrary.Utils;
+
 namespace Squidex.ClientLibrary
 {
-    public abstract class SquidexClientBase
+    public abstract class SquidexClientBase : IDisposable
     {
-        protected Func<HttpClient> HttpClientFactory { get; }
+        protected HttpClient HttpClient { get; }
 
         protected Uri ServiceUrl { get; }
 
         protected string ApplicationName { get; }
 
-        protected SquidexClientBase(Uri serviceUrl, string applicationName, string schemaName, Func<HttpClient> httpClientFactory)
+        protected SquidexClientBase(Uri serviceUrl, string applicationName, IAuthenticator authenticator)
         {
             Guard.NotNull(serviceUrl, nameof(serviceUrl));
-            Guard.NotNull(httpClientFactory, nameof(httpClientFactory));
             Guard.NotNullOrEmpty(applicationName, nameof(applicationName));
 
-            HttpClientFactory = httpClientFactory;
+            HttpClient = new HttpClient(new AuthenticatingHttpClientHandler(authenticator), true);
             ApplicationName = applicationName;
             ServiceUrl = serviceUrl;
         }
 
         protected async Task<HttpResponseMessage> RequestAsync(HttpMethod method, string path, HttpContent content = null, QueryContext context = null)
         {
-            using (var httpClient = HttpClientFactory())
+            var uri = new Uri(ServiceUrl, path);
+
+            using (var request = BuildRequest(method, uri, content, context))
             {
-                var uri = new Uri(ServiceUrl, path);
+                var response = await HttpClient.SendAsync(request);
 
-                using (var request = BuildRequest(method, uri, content, context))
-                {
-                    var response = await httpClient.SendAsync(request);
+                await EnsureResponseIsValidAsync(response);
 
-                    await EnsureResponseIsValidAsync(response);
-
-                    return response;
-                }
+                return response;
             }
         }
 
@@ -92,6 +90,11 @@ namespace Squidex.ClientLibrary
 
                 throw new SquidexException(message);
             }
+        }
+
+        public void Dispose()
+        {
+            this.HttpClient?.Dispose();
         }
     }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientManager.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientManager.cs
@@ -124,7 +124,7 @@ namespace Squidex.ClientLibrary
 
         public SquidexAssetClient GetAssetClient()
         {
-            return new SquidexAssetClient(serviceUrl, applicationName, string.Empty, CreateHttpClient);
+            return new SquidexAssetClient(serviceUrl, applicationName, authenticator);
         }
 
         public SquidexClient<TEntity, TData> GetClient<TEntity, TData>(string schemaName)
@@ -133,7 +133,7 @@ namespace Squidex.ClientLibrary
         {
             Guard.NotNullOrEmpty(schemaName, nameof(schemaName));
 
-            return new SquidexClient<TEntity, TData>(serviceUrl, applicationName, schemaName, CreateHttpClient);
+            return new SquidexClient<TEntity, TData>(serviceUrl, applicationName, schemaName, authenticator);
         }
 
         private HttpClient CreateHttpClient()

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientManager.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientManager.cs
@@ -19,7 +19,6 @@ namespace Squidex.ClientLibrary
         private readonly string applicationName;
         private readonly Uri serviceUrl;
         private readonly IAuthenticator authenticator;
-        private readonly HttpMessageHandler messageHandler;
 
         public string App
         {
@@ -45,8 +44,6 @@ namespace Squidex.ClientLibrary
             this.authenticator = authenticator;
             this.applicationName = applicationName;
             this.serviceUrl = serviceUrl;
-
-            messageHandler = new AuthenticatingHttpClientHandler(authenticator);
         }
 
         public string GenerateImageUrl(string id)
@@ -127,7 +124,7 @@ namespace Squidex.ClientLibrary
 
         public SquidexAssetClient GetAssetClient()
         {
-            return new SquidexAssetClient(serviceUrl, applicationName, string.Empty, messageHandler);
+            return new SquidexAssetClient(serviceUrl, applicationName, string.Empty, CreateHttpClient);
         }
 
         public SquidexClient<TEntity, TData> GetClient<TEntity, TData>(string schemaName)
@@ -136,14 +133,14 @@ namespace Squidex.ClientLibrary
         {
             Guard.NotNullOrEmpty(schemaName, nameof(schemaName));
 
-            return new SquidexClient<TEntity, TData>(serviceUrl, applicationName, schemaName, messageHandler);
+            return new SquidexClient<TEntity, TData>(serviceUrl, applicationName, schemaName, CreateHttpClient);
         }
 
         private HttpClient CreateHttpClient()
         {
             var url = new Uri(serviceUrl, "/api/");
 
-            return new HttpClient(messageHandler) { BaseAddress = url };
+            return new HttpClient(new AuthenticatingHttpClientHandler(authenticator)) { BaseAddress = url };
         }
     }
 }


### PR DESCRIPTION
The code ```using (var httpClient = new HttpClient(messageHandler))``` causes problems in that HttpClient takes responsibility for the disposable of the message handler and then any subsequent requests to the client fail with "access to disposed object". It appears to need a new instance per HttpClient.

Also, take a look at the new IHttpClientFactory interface: https://docs.microsoft.com/en-us/dotnet/api/system.net.http.ihttpclientfactory?view=aspnetcore-2.2

This code change lends itself well to adding support for the IHttpClientFactory.

Fixes #18 