### PR TITLE
GetAllAsync and GetAllAssetsAsync added as helper extensions.

### DIFF
--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientExtensions.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientExtensions.cs
@@ -1,0 +1,51 @@
+using System.Threading.Tasks;
+
+namespace Squidex.ClientLibrary
+{
+    public static class SquidexClientExtensions
+    {
+        public static async Task<SquidexEntities<TEntity, TData>> GetAllAsync<TEntity, TData>(
+            this SquidexClient<TEntity, TData> client,
+            int batchSize = 200)
+            where TEntity : SquidexEntityBase<TData>
+            where TData : class, new()
+        {
+            Guard.NotNull(client, nameof(client));
+
+            int skip = 0;
+            var entities = new SquidexEntities<TEntity, TData>();
+            do
+            {
+                var getResult = await client.GetAsync(skip: skip, top: batchSize);
+
+                entities.Total = getResult.Total;
+                entities.Items.AddRange(getResult.Items);
+
+                skip += entities.Items.Count;
+            }
+            while (skip < entities.Total);
+
+            return entities;
+        }
+
+        public static async Task<AssetEntities> GetAllAssetsAsync(this SquidexAssetClient assetClient, int batchSize = 200)
+        {
+            Guard.NotNull(assetClient, nameof(assetClient));
+
+            int skip = 0;
+            var entities = new AssetEntities();
+            do
+            {
+                var getResult = await assetClient.GetAssetsAsync(skip: skip, top: batchSize);
+
+                entities.Total = getResult.Total;
+                entities.Items.AddRange(getResult.Items);
+
+                skip += entities.Items.Count;
+            }
+            while (skip < entities.Total);
+
+            return entities;
+        }
+    }
+}


### PR DESCRIPTION
I ran a-fowl of the max items and created this simple little tool for pulling all items. It simply adds "GetAllAsync" and "GetAllAssetsAsync()" to the clients using their public API.

In my situation, I need to pull all data (and cache it) because it's used for fuzzy business logic processing -- there would be no way to query what I need.

Thanks!