### PR TITLE
Fix null ref on CLI validators

### DIFF
--- a/cli/Squidex.CLI/Squidex.CLI/Program.cs
+++ b/cli/Squidex.CLI/Squidex.CLI/Program.cs
@@ -6,8 +6,11 @@
 // ==========================================================================
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using CommandDotNet;
 using CommandDotNet.IoC.MicrosoftDependencyInjection;
+using FluentValidation.Attributes;
 using Microsoft.Extensions.DependencyInjection;
 using Squidex.CLI.Commands;
 using Squidex.CLI.Configuration;
@@ -21,6 +24,11 @@ namespace Squidex.CLI
             var serviceCollection =
                 new ServiceCollection()
                     .AddSingleton<IConfigurationService, ConfigurationService>();
+
+            foreach (var validator in GetAllValidatorTypes())
+            {
+                serviceCollection.AddSingleton(validator);
+            }
 
             var serviceProvider = serviceCollection.BuildServiceProvider();
 
@@ -36,5 +44,13 @@ namespace Squidex.CLI
                 return -1;
             }
         }
+
+        private static IEnumerable<Type> GetAllValidatorTypes() =>
+            typeof(Program)
+                .Assembly
+                .GetTypes()
+                .SelectMany(t => t
+                    .GetCustomAttributes(typeof(ValidatorAttribute), false)
+                    .Select(a => ((ValidatorAttribute)a).ValidatorType));
     }
 }


### PR DESCRIPTION
# Problem

I downloaded the official [Squidex CLI v3.1 release](https://github.com/Squidex/squidex-samples/releases/tag/cli-v3.1) and many commands I tried to run (e.g. `sq config list`) failed with the message:

```text
ERROR: Object reference not set to an instance of an object.
```

# The Fix

The validation attributes provided were not being picked up by CommandDotNet correctly and throwing a NullReferenceException from within ModelValidator. This explicitly registers all validators so they are made available to command line parsing.