### PR TITLE
Revert DotCommand temporary workaround

### DIFF
--- a/cli/Squidex.CLI/Squidex.CLI/Program.cs
+++ b/cli/Squidex.CLI/Squidex.CLI/Program.cs
@@ -6,11 +6,8 @@
 // ==========================================================================
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using CommandDotNet;
 using CommandDotNet.IoC.MicrosoftDependencyInjection;
-using FluentValidation.Attributes;
 using Microsoft.Extensions.DependencyInjection;
 using Squidex.CLI.Commands;
 using Squidex.CLI.Configuration;
@@ -24,11 +21,6 @@ namespace Squidex.CLI
             var serviceCollection =
                 new ServiceCollection()
                     .AddSingleton<IConfigurationService, ConfigurationService>();
-
-            foreach (var validator in GetAllValidatorTypes())
-            {
-                serviceCollection.AddSingleton(validator);
-            }
 
             var serviceProvider = serviceCollection.BuildServiceProvider();
 
@@ -44,13 +36,5 @@ namespace Squidex.CLI
                 return -1;
             }
         }
-
-        private static IEnumerable<Type> GetAllValidatorTypes() =>
-            typeof(Program)
-                .Assembly
-                .GetTypes()
-                .SelectMany(t => t
-                    .GetCustomAttributes(typeof(ValidatorAttribute), false)
-                    .Select(a => ((ValidatorAttribute)a).ValidatorType));
     }
 }

--- a/cli/Squidex.CLI/Squidex.CLI/Squidex.CLI.csproj
+++ b/cli/Squidex.CLI/Squidex.CLI/Squidex.CLI.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConsoleTables" Version="2.3.0" />
-    <PackageReference Include="CommandDotNet" Version="2.8.1" />
+    <PackageReference Include="CommandDotNet" Version="2.8.2" />
     <PackageReference Include="CommandDotNet.IoC.MicrosoftDependencyInjection" Version="1.1.0" />
     <PackageReference Include="CoreTweet" Version="1.0.0.483" />
     <PackageReference Include="CsvHelper" Version="12.1.2" />


### PR DESCRIPTION
This [removes a temporary workaround](https://github.com/Squidex/squidex-samples/pull/33) which was caused by a `NullReferenceException` in DotCommand 2.8.1. The upgrade to DotCommand 2.8.2 removes the need for the workaround.