### PR TITLE
Update name of header used for AssetUrlsToResolve

### DIFF
--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/QueryContext.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/QueryContext.cs
@@ -82,7 +82,7 @@ namespace Squidex.ClientLibrary
 
                 if (!string.IsNullOrWhiteSpace(assetFields))
                 {
-                    headers.TryAddWithoutValidation("X-AssetFields", assetFields);
+                    headers.TryAddWithoutValidation("X-Resolve-Urls", assetFields);
                 }
             }
         }


### PR DESCRIPTION
It seems that the header expected for ResolveAssetUrls in Squidex has changed name. This is an update to reflect that change in the Squidex Client Library.

[Squidex source code](https://github.com/Squidex/squidex/blob/fca8bb8bcfd415d1ad267353eaf5df33f14724d3/src/Squidex.Domain.Apps.Entities/Contents/ContextExtensions.cs#L21)

[Comment regarding the issue](https://support.squidex.io/t/is-there-an-easier-way-to-save-the-full-url-of-an-image-in-your-page/330/10?u=niclaslindqvist) from @SebastianStehle