### PR TITLE
Convert CLI to dotnet tool

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -51,6 +51,16 @@ jobs:
         cd cli/Squidex.CLI/Squidex.CLI
         dotnet publish -r osx-x64 -c Release /p:PublishSingleFile=true /p:PublishTrimmed=true
 
+    - name: pack dotnet tool
+      run: |
+        cd cli/Squidex.CLI/Squidex.CLI
+        dotnet pack -p:PackDotnetTool=1 -c Release
+
+    - name: push dotnet tool to nuget.org
+      run: |
+        cd cli/Squidex.CLI/Squidex.CLI/bin/Release
+        dotnet nuget push *.nupkg --source 'https://api.nuget.org/v3/index.json' -k ${{ secrets.nuget }}
+
     - name: create dir
       run: |
         mkdir cli/Squidex.CLI/Squidex.CLI/bin/Release/out

--- a/cli/Squidex.CLI/Squidex.CLI/Squidex.CLI.csproj
+++ b/cli/Squidex.CLI/Squidex.CLI/Squidex.CLI.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <AssemblyName Condition="'$(PackDotnetTool)'!='1'">sq</AssemblyName>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <Version>4.0</Version>

--- a/cli/Squidex.CLI/Squidex.CLI/Squidex.CLI.csproj
+++ b/cli/Squidex.CLI/Squidex.CLI/Squidex.CLI.csproj
@@ -1,10 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <AssemblyName>sq</AssemblyName>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <Version>4.0</Version>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>sq</ToolCommandName>
+    <Authors>sebastianstehle</Authors>
+    <Company>Squidex UG (haftungsbeschränkt)</Company>
+    <Description>Command Line Interface for Squidex Headless CMS</Description>
+    <Copyright>MIT</Copyright>
+    <PackageTags>Squidex HeadlessCMS</PackageTags>
+    <PackageIconUrl>https://raw.githubusercontent.com/Squidex/squidex/master/media/logo-squared.png</PackageIconUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/Squidex/squidex/</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConsoleTables" Version="2.3.0" />


### PR DESCRIPTION
This converts the CLI into a dotnet tool (https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-install) so that it can be installed via `dotnet tool install` rather than downloading binaries off of github.

Once this is compiled and pushed up to nuget.org, users can install via:

```
$ dotnet tool install --global --version 4.0.0
```

The above command would download, install, and make available a global `sq` command that can be run from anywhere, regardless of operating system.

~~BREAKING CHANGE: The assembly name of the compiled output was changed from `sq` to `Squidex.CLI` to comply with nuget standards.~~ **UPDATE** - The build output assembly name now defaults to `sq` but if you pass the build property `PackDotnetTool=1`, it will build nuget-friendly output ([see this comment](https://github.com/Squidex/squidex-samples/pull/36#issuecomment-564980785))