### PR TITLE
Added ISquidexClientManager interface to increase "mockability"

### DIFF
--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/ISquidexClientManager.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/ISquidexClientManager.cs
@@ -1,0 +1,35 @@
+// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System.Collections.Generic;
+using System.Net.Http;
+using Squidex.ClientLibrary.Management;
+
+namespace Squidex.ClientLibrary
+{
+    public interface ISquidexClientManager
+    {
+        SquidexOptions Options { get; }
+        string GenerateImageUrl(string id);
+        string GenerateImageUrl(IEnumerable<string> id);
+        IAppsClient CreateAppsClient();
+        IAssetsClient CreateAssetsClient();
+        IBackupsClient CreateBackupsClient();
+        ICommentsClient CreateCommentsClient();
+        IHistoryClient CreateHistoryClient();
+        ILanguagesClient CreateLanguagesClient();
+        IPingClient CreatePingClient();
+        IPlansClient CreatePlansClient();
+        IRulesClient CreateRulesClient();
+        ISchemasClient CreateSchemasClient();
+        IStatisticsClient CreateStatisticsClient();
+        IUsersClient CreateUsersClient();
+        IExtendableRulesClient CreateExtendableRulesClient();
+        IContentsClient<TEntity, TData> CreateContentsClient<TEntity, TData>(string schemaName) where TEntity : Content<TData> where TData : class, new();
+        HttpClient CreateHttpClient();
+    }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/ISquidexClientManager.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/ISquidexClientManager.cs
@@ -14,22 +14,39 @@ namespace Squidex.ClientLibrary
     public interface ISquidexClientManager
     {
         SquidexOptions Options { get; }
+
         string GenerateImageUrl(string id);
+
         string GenerateImageUrl(IEnumerable<string> id);
+
         IAppsClient CreateAppsClient();
+
         IAssetsClient CreateAssetsClient();
+
         IBackupsClient CreateBackupsClient();
+
         ICommentsClient CreateCommentsClient();
+
         IHistoryClient CreateHistoryClient();
+
         ILanguagesClient CreateLanguagesClient();
+
         IPingClient CreatePingClient();
+
         IPlansClient CreatePlansClient();
+
         IRulesClient CreateRulesClient();
+
         ISchemasClient CreateSchemasClient();
+
         IStatisticsClient CreateStatisticsClient();
+
         IUsersClient CreateUsersClient();
+
         IExtendableRulesClient CreateExtendableRulesClient();
+
         IContentsClient<TEntity, TData> CreateContentsClient<TEntity, TData>(string schemaName) where TEntity : Content<TData> where TData : class, new();
+
         HttpClient CreateHttpClient();
     }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientManager.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientManager.cs
@@ -14,7 +14,7 @@ using Squidex.ClientLibrary.Utils;
 
 namespace Squidex.ClientLibrary
 {
-    public sealed partial class SquidexClientManager
+    public sealed partial class SquidexClientManager : ISquidexClientManager
     {
         public string App
         {


### PR DESCRIPTION
# What have I done?
I added an interface to SquidexClientManager. Nothing more, nothing less.

# Reason for this pull request
I was writing a test suite for the domain layer of one my services and stumbled upon the fact that the SquidexClientManager class was sealed. Therefore Moq was not able to mock this class for me (because it can not inherit from the base class). 
## Example
```csharp
var squidex = new Mock<SquidexClientManager>().Object; // <-- This currently fails
```
With the added interface it would now be possible to mock the entire class if the developer decides to mock the interface instead.