### PR TITLE
Feature/http client timeout

### DIFF
--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientManager.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientManager.cs
@@ -178,7 +178,7 @@ namespace Squidex.ClientLibrary
 
             httpClient.BaseAddress = url;
 
-            httpClient.Timeout = Options.HttpClientTimeOut;
+            httpClient.Timeout = Options.HttpClientTimeout;
 
             Options.Configurator.Configure(httpClient);
 

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientManager.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexClientManager.cs
@@ -178,6 +178,8 @@ namespace Squidex.ClientLibrary
 
             httpClient.BaseAddress = url;
 
+            httpClient.Timeout = Options.HttpClientTimeOut;
+
             Options.Configurator.Configure(httpClient);
 
             return httpClient;

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexOptions.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexOptions.cs
@@ -24,7 +24,7 @@ namespace Squidex.ClientLibrary
         private IAuthenticator authenticator;
         private IHttpConfigurator configurator;
         private IHttpClientFactory clientFactory;
-        private TimeSpan httpClientTimeOut;
+        private TimeSpan httpClientTimeout;
         private bool isFrozen;
 
         public string Url { get => url; set => url = value; }
@@ -156,14 +156,17 @@ namespace Squidex.ClientLibrary
             }
         }
 
-        public TimeSpan HttpClientTimeOut
+        public TimeSpan HttpClientTimeout
         {
-            get => httpClientTimeOut;
+            get
+            {
+                return httpClientTimeout;
+            }
             set
             {
                 ThrowIfFrozen();
 
-                httpClientTimeOut = value;
+                httpClientTimeout = value;
             }
         }
 
@@ -238,9 +241,9 @@ namespace Squidex.ClientLibrary
                 clientFactory = NoopHttpConfigurator.Instance;
             }
 
-            if (httpClientTimeOut == TimeSpan.Zero)
+            if (httpClientTimeout == TimeSpan.Zero)
             {
-                httpClientTimeOut = TimeSpan.FromSeconds(100);
+                httpClientTimeout = TimeSpan.FromSeconds(100);
             }
 
             isFrozen = true;

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexOptions.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexOptions.cs
@@ -24,6 +24,7 @@ namespace Squidex.ClientLibrary
         private IAuthenticator authenticator;
         private IHttpConfigurator configurator;
         private IHttpClientFactory clientFactory;
+        private TimeSpan httpClientTimeOut;
         private bool isFrozen;
 
         public string Url { get => url; set => url = value; }
@@ -155,6 +156,17 @@ namespace Squidex.ClientLibrary
             }
         }
 
+        public TimeSpan HttpClientTimeOut
+        {
+            get => httpClientTimeOut;
+            set
+            {
+                ThrowIfFrozen();
+
+                httpClientTimeOut = value;
+            }
+        }
+
         private void ThrowIfFrozen()
         {
             if (isFrozen)
@@ -224,6 +236,11 @@ namespace Squidex.ClientLibrary
             if (clientFactory == null)
             {
                 clientFactory = NoopHttpConfigurator.Instance;
+            }
+
+            if (httpClientTimeOut == TimeSpan.Zero)
+            {
+                httpClientTimeOut = TimeSpan.FromMinutes(2);
             }
 
             isFrozen = true;

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexOptions.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/SquidexOptions.cs
@@ -240,7 +240,7 @@ namespace Squidex.ClientLibrary
 
             if (httpClientTimeOut == TimeSpan.Zero)
             {
-                httpClientTimeOut = TimeSpan.FromMinutes(2);
+                httpClientTimeOut = TimeSpan.FromSeconds(100);
             }
 
             isFrozen = true;


### PR DESCRIPTION
We needed a shorter timeout value for the Client-lib, so I figured I would just send you a PR for it.

I took a brief look, and I see that the HttpClient is being used inside a using statement some places, and that you manually create HttpClients. I would suggest a design change in the library since we can leverage the manual work from creating HttpClient's to Microsofts own implementation of this. See [here](https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests#issues-with-the-original-httpclient-class-available-in-net-core)

I see that you have named an interface IHttpClientFactory already - This would have to change to a more fitting title, so the .NET IHttpClientFactory can be injected into the SquidexOptions.

Let me hear your thoughts on it.
