### PR TITLE
import/export singleton schemas

### DIFF
--- a/cli/Squidex.CLI/Squidex.CLI/Commands/Implementation/Sync/Schemas/SchemaCreateModel.cs
+++ b/cli/Squidex.CLI/Squidex.CLI/Commands/Implementation/Sync/Schemas/SchemaCreateModel.cs
@@ -10,6 +10,7 @@ namespace Squidex.CLI.Commands.Implementation.Sync.Schemas
     public sealed class SchemaCreateModel
     {
         public string Name { get; set; }
+
         public bool IsSingleton { get; set; }
     }
 }

--- a/cli/Squidex.CLI/Squidex.CLI/Commands/Implementation/Sync/Schemas/SchemaCreateModel.cs
+++ b/cli/Squidex.CLI/Squidex.CLI/Commands/Implementation/Sync/Schemas/SchemaCreateModel.cs
@@ -7,8 +7,9 @@
 
 namespace Squidex.CLI.Commands.Implementation.Sync.Schemas
 {
-    public sealed class SchemaModelNameOnly
+    public sealed class SchemaCreateModel
     {
         public string Name { get; set; }
+        public bool IsSingleton { get; set; }
     }
 }

--- a/cli/Squidex.CLI/Squidex.CLI/Commands/Implementation/Sync/Schemas/SchemasSynchronizer.cs
+++ b/cli/Squidex.CLI/Squidex.CLI/Commands/Implementation/Sync/Schemas/SchemasSynchronizer.cs
@@ -41,7 +41,8 @@ namespace Squidex.CLI.Commands.Implementation.Sync.Schemas
 
                     var model = new SchemeModel
                     {
-                        Name = schema.Name
+                        Name = schema.Name,
+                        IsSingleton = details.IsSingleton
                     };
 
                     model.Schema = jsonHelper.Convert<SynchronizeSchemaDto>(details);
@@ -57,7 +58,7 @@ namespace Squidex.CLI.Commands.Implementation.Sync.Schemas
         {
             var newSchemaNames =
                 GetSchemaFiles(directoryInfo)
-                    .Select(x => jsonHelper.Read<SchemaModelNameOnly>(x, log))
+                    .Select(x => jsonHelper.Read<SchemaCreateModel>(x, log))
                     .ToList();
 
             if (!newSchemaNames.HasDistinctNames(x => x.Name))
@@ -95,7 +96,8 @@ namespace Squidex.CLI.Commands.Implementation.Sync.Schemas
                 {
                     var request = new CreateSchemaDto
                     {
-                        Name = newSchema.Name
+                        Name = newSchema.Name,
+                        IsSingleton = newSchema.IsSingleton
                     };
 
                     var created = await session.Schemas.PostSchemaAsync(session.App, request);

--- a/cli/Squidex.CLI/Squidex.CLI/Commands/Implementation/Sync/Schemas/SchemeModel.cs
+++ b/cli/Squidex.CLI/Squidex.CLI/Commands/Implementation/Sync/Schemas/SchemeModel.cs
@@ -13,6 +13,8 @@ namespace Squidex.CLI.Commands.Implementation.Sync.Schemas
     {
         public string Name { get; set; }
 
+        public bool IsSingleton { get; set; }
+
         public SynchronizeSchemaDto Schema { get; set; }
     }
 }


### PR DESCRIPTION
Added possibility to correctly export/import singleton schemas in  Squidex CLI.

Currently Squidex CLI has an issue with export/import of singleton schemas. Schema is always multiple in case you create it from CLI.

Steps to reproduce issue:
1. Create new test `Single content` schema in Squidex CMS.
2. Run export `dotnet sq sync out`.
3. Delete test `Single content` schema from Squidex CMS.
4. Run import `dotnet sq sync in`
5. Now test schema became of `Multiple contents` type, but it must remain `Single content`