### PR TITLE
+ EnrichedEvent models and deserialization utils

### DIFF
--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary.Tests/EnrichedEvents/EnrichedEventsTests.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary.Tests/EnrichedEvents/EnrichedEventsTests.cs
@@ -1,0 +1,128 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Squidex.ClientLibrary.EnrichedEvents;
+using Xunit;
+
+namespace Squidex.ClientLibrary.Tests.EnrichedEvents
+{
+  public class EnrichedEventsTests
+  {
+    private string json_EnrichedContentEvent = @"{
+			""type"": ""SchemaUpdated"",
+			""payload"": {
+				""$type"": ""EnrichedContentEvent"",
+				""type"": ""Updated"",
+				""id"": ""062b936f-7496-4f87-bd4f-ba7bbb63c751"",
+				""created"": ""2021-01-01T00:00:00Z"",
+				""lastModified"": ""2021-01-01T00:01:00Z"",
+				""createdBy"": ""subject:601c2cbafa4e669f214c0438"",
+				""lastModifiedBy"": ""subject:601c2cbafa4e669f214c0438"",
+				""data"": {
+					""testField"": {
+						""iv"": ""test2""
+					}
+				},
+				""dataOld"": {
+					""testField"": {
+						""iv"": ""test""
+					}
+				},
+				""status"": ""Published"",
+				""partition"": -792991992,
+				""schemaId"": ""062b936f-7496-4f87-bd4f-ba7bbb63c751,schema"",
+				""actor"": ""subject:601c2cbafa4e669f214c0438"",
+				""appId"": ""3e2df825-86a9-43cb-8eb7-97d5a5bd4eea,testapp"",
+				""timestamp"": ""2021-01-01T00:01:00Z"",
+				""name"": ""SchemaUpdated"",
+				""version"": 3
+			},
+			""timestamp"": ""2021-01-01T00:01:00Z""
+		}";
+
+    [Fact]
+    public void Should_deserialize_EnrichedContentEvent()
+    {
+      var envelope = JsonConvert.DeserializeObject<EnrichedEventEnvelope>(json_EnrichedContentEvent, new JsonSerializerSettings
+      {
+        TypeNameHandling = TypeNameHandling.Objects,
+        SerializationBinder = new EnrichedEventSerializationBinder()
+      });
+
+      Assert.True(envelope.Payload is EnrichedContentEvent);
+
+      var contentEvent = envelope.Payload as EnrichedContentEvent;
+
+      Assert.Equal("SchemaUpdated", contentEvent.Name);
+      Assert.Equal("testapp", contentEvent.AppName);
+      Assert.Equal("601c2cbafa4e669f214c0438", contentEvent.ActorId);
+      Assert.Equal(typeof(JObject), contentEvent.Data.GetType());
+
+      switch (contentEvent.SchemaName)
+      {
+        case "schema":
+          var res = contentEvent.ToTypedContent<SchemaData>();
+
+          Assert.Equal(typeof(EnrichedContentEvent<SchemaData>), res.GetType());
+          Assert.Equal(typeof(SchemaData), res.Data.GetType());
+
+          Assert.Equal("test2", res.Data.TestField);
+          Assert.Equal("test", res.DataOld.TestField);
+          break;
+        default: throw new Exception("Unknown schema");
+      }
+    }
+
+    private string json_EnrichedCommentEvent = @"{
+		""type"": ""UserMentioned"",
+		""payload"": {
+			""$type"": ""EnrichedCommentEvent"",
+			""text"": ""@user@test.com testmessage"",
+			""url"": ""/app/testapp/content/schema/0e5955e3-cd2a-49f2-92ba-303acf4dd192/comments"",
+			""partition"": -1730311374,
+			""actor"": ""subject:601c2cbafa4e669f214c0438"",
+			""appId"": ""3e2df825-86a9-43cb-8eb7-97d5a5bd4eea,testapp"",
+			""timestamp"": ""2021-01-01T00:00:00Z"",
+			""name"": ""UserMentioned"",
+			""version"": 0
+		},
+		""timestamp"": ""2021-01-01T00:00:00Z""
+	}";
+
+    [Fact]
+    public void Should_deserialize_EnrichedCommentEvent()
+    {
+      var envelope = JsonConvert.DeserializeObject<EnrichedEventEnvelope>(json_EnrichedCommentEvent, new JsonSerializerSettings
+      {
+        TypeNameHandling = TypeNameHandling.Objects,
+        SerializationBinder = new EnrichedEventSerializationBinder()
+      });
+
+      Assert.True(envelope.Payload is EnrichedCommentEvent);
+
+      var contentEvent = envelope.Payload as EnrichedCommentEvent;
+
+      Assert.Equal("@user@test.com testmessage", contentEvent.Text);
+      Assert.Equal("UserMentioned", contentEvent.Name);
+      Assert.Equal("testapp", contentEvent.AppName);
+      Assert.Equal("601c2cbafa4e669f214c0438", contentEvent.ActorId);
+    }
+  }
+
+  public class SchemaData
+  {
+    [JsonConverter(typeof(InvariantConverter))]
+    public string TestField { get; set; }
+  }
+
+  public class Schema : Content<SchemaData>
+  {
+  }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary.Tests/EnrichedEvents/EnrichedEventsTests.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary.Tests/EnrichedEvents/EnrichedEventsTests.cs
@@ -9,13 +9,14 @@ using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Squidex.ClientLibrary.EnrichedEvents;
+using Squidex.ClientLibrary.Utils;
 using Xunit;
 
 namespace Squidex.ClientLibrary.Tests.EnrichedEvents
 {
-  public class EnrichedEventsTests
-  {
-    private string json_EnrichedContentEvent = @"{
+    public class EnrichedEventsTests
+    {
+        private string jsonEnrichedContentEvent = @"{
 			""type"": ""SchemaUpdated"",
 			""payload"": {
 				""$type"": ""EnrichedContentEvent"",
@@ -47,40 +48,36 @@ namespace Squidex.ClientLibrary.Tests.EnrichedEvents
 			""timestamp"": ""2021-01-01T00:01:00Z""
 		}";
 
-    [Fact]
-    public void Should_deserialize_EnrichedContentEvent()
-    {
-      var envelope = JsonConvert.DeserializeObject<EnrichedEventEnvelope>(json_EnrichedContentEvent, new JsonSerializerSettings
-      {
-        TypeNameHandling = TypeNameHandling.Objects,
-        SerializationBinder = new EnrichedEventSerializationBinder()
-      });
+        [Fact]
+        public void Should_deserialize_EnrichedContentEvent()
+        {
+            var envelope = EnrichedEventEnvelope.DeserializeEnvelope(jsonEnrichedContentEvent);
 
-      Assert.True(envelope.Payload is EnrichedContentEvent);
+            Assert.True(envelope.Payload is EnrichedContentEvent);
 
-      var contentEvent = envelope.Payload as EnrichedContentEvent;
+            var contentEvent = envelope.Payload as EnrichedContentEvent;
 
-      Assert.Equal("SchemaUpdated", contentEvent.Name);
-      Assert.Equal("testapp", contentEvent.AppName);
-      Assert.Equal("601c2cbafa4e669f214c0438", contentEvent.ActorId);
-      Assert.Equal(typeof(JObject), contentEvent.Data.GetType());
+            Assert.Equal("SchemaUpdated", contentEvent.Name);
+            Assert.Equal("testapp", contentEvent.App.Name);
+            Assert.Equal("601c2cbafa4e669f214c0438", contentEvent.Actor.Id);
+            Assert.Equal(typeof(JObject), contentEvent.Data.GetType());
 
-      switch (contentEvent.SchemaName)
-      {
-        case "schema":
-          var res = contentEvent.ToTyped<SchemaData>();
+            switch (contentEvent.Schema.Name)
+            {
+                case "schema":
+                    var res = contentEvent.ToTyped<SchemaData>();
 
-          Assert.Equal(typeof(EnrichedContentEvent<SchemaData>), res.GetType());
-          Assert.Equal(typeof(SchemaData), res.Data.GetType());
+                    Assert.Equal(typeof(EnrichedContentEvent<SchemaData>), res.GetType());
+                    Assert.Equal(typeof(SchemaData), res.Data.GetType());
 
-          Assert.Equal("test2", res.Data.TestField);
-          Assert.Equal("test", res.DataOld.TestField);
-          break;
-        default: throw new Exception("Unknown schema");
-      }
-    }
+                    Assert.Equal("test2", res.Data.TestField);
+                    Assert.Equal("test", res.DataOld.TestField);
+                    break;
+                default: throw new Exception("Unknown schema");
+            }
+        }
 
-    private string json_EnrichedCommentEvent = @"{
+        private string jsonEnrichedCommentEvent = @"{
 		""type"": ""UserMentioned"",
 		""payload"": {
 			""$type"": ""EnrichedCommentEvent"",
@@ -96,33 +93,29 @@ namespace Squidex.ClientLibrary.Tests.EnrichedEvents
 		""timestamp"": ""2021-01-01T00:00:00Z""
 	}";
 
-    [Fact]
-    public void Should_deserialize_EnrichedCommentEvent()
-    {
-      var envelope = JsonConvert.DeserializeObject<EnrichedEventEnvelope>(json_EnrichedCommentEvent, new JsonSerializerSettings
-      {
-        TypeNameHandling = TypeNameHandling.Objects,
-        SerializationBinder = new EnrichedEventSerializationBinder()
-      });
+        [Fact]
+        public void Should_deserialize_EnrichedCommentEvent()
+        {
+            var envelope = EnrichedEventEnvelope.DeserializeEnvelope(jsonEnrichedCommentEvent);
 
-      Assert.True(envelope.Payload is EnrichedCommentEvent);
+            Assert.True(envelope.Payload is EnrichedCommentEvent);
 
-      var contentEvent = envelope.Payload as EnrichedCommentEvent;
+            var contentEvent = envelope.Payload as EnrichedCommentEvent;
 
-      Assert.Equal("@user@test.com testmessage", contentEvent.Text);
-      Assert.Equal("UserMentioned", contentEvent.Name);
-      Assert.Equal("testapp", contentEvent.AppName);
-      Assert.Equal("601c2cbafa4e669f214c0438", contentEvent.ActorId);
+            Assert.Equal("@user@test.com testmessage", contentEvent.Text);
+            Assert.Equal("UserMentioned", contentEvent.Name);
+            Assert.Equal("testapp", contentEvent.App.Name);
+            Assert.Equal("601c2cbafa4e669f214c0438", contentEvent.Actor.Id);
+        }
     }
-  }
 
-  public class SchemaData
-  {
-    [JsonConverter(typeof(InvariantConverter))]
-    public string TestField { get; set; }
-  }
+    public class SchemaData
+    {
+        [JsonConverter(typeof(InvariantConverter))]
+        public string TestField { get; set; }
+    }
 
-  public class Schema : Content<SchemaData>
-  {
-  }
+    public class Schema : Content<SchemaData>
+    {
+    }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary.Tests/EnrichedEvents/EnrichedEventsTests.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary.Tests/EnrichedEvents/EnrichedEventsTests.cs
@@ -68,7 +68,7 @@ namespace Squidex.ClientLibrary.Tests.EnrichedEvents
       switch (contentEvent.SchemaName)
       {
         case "schema":
-          var res = contentEvent.ToTypedContent<SchemaData>();
+          var res = contentEvent.ToTyped<SchemaData>();
 
           Assert.Equal(typeof(EnrichedContentEvent<SchemaData>), res.GetType());
           Assert.Equal(typeof(SchemaData), res.Data.GetType());

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedAssetEvent.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedAssetEvent.cs
@@ -1,0 +1,77 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System;
+using Squidex.ClientLibrary.Management;
+
+namespace Squidex.ClientLibrary.EnrichedEvents
+{
+  public sealed class EnrichedAssetEvent : EnrichedUserEventBase, IEnrichedEntityEvent
+  {
+    public EnrichedAssetEventType Type { get; set; }
+
+    public string Id { get; set; }
+
+    public DateTimeOffset Created { get; set; }
+
+    public DateTimeOffset LastModified { get; set; }
+
+    public string CreatedBy { get; set; }
+
+    public string LastModifiedBy { get; set; }
+
+    public string MimeType { get; set; }
+
+    public string FileName { get; set; }
+
+    public long FileVersion { get; set; }
+
+    public long FileSize { get; set; }
+
+    public int? PixelWidth { get; set; }
+
+    public int? PixelHeight { get; set; }
+
+    public AssetType AssetType { get; set; }
+
+    public bool IsImage { get; set; }
+
+    public override long Partition { get; set; }
+
+    public string CreatedById
+    {
+      get
+      {
+        return CreatedBy == null ? null : CreatedBy.Contains(":") ? CreatedBy.Split(':')[1] : null;
+      }
+    }
+
+    public string CreatedByType
+    {
+      get
+      {
+        return CreatedBy == null ? null : CreatedBy.Contains(":") ? CreatedBy.Split(':')[0] : null;
+      }
+    }
+
+    public string LastModifiedById
+    {
+      get
+      {
+        return LastModifiedBy == null ? null : LastModifiedBy.Contains(":") ? LastModifiedBy.Split(':')[1] : null;
+      }
+    }
+
+    public string LastModifiedByType
+    {
+      get
+      {
+        return LastModifiedBy == null ? null : LastModifiedBy.Contains(":") ? LastModifiedBy.Split(':')[0] : null;
+      }
+    }
+  }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedAssetEvent.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedAssetEvent.cs
@@ -6,72 +6,89 @@
 // ==========================================================================
 
 using System;
+using Newtonsoft.Json;
 using Squidex.ClientLibrary.Management;
+using Squidex.ClientLibrary.Utils;
 
 namespace Squidex.ClientLibrary.EnrichedEvents
 {
-  public sealed class EnrichedAssetEvent : EnrichedUserEventBase, IEnrichedEntityEvent
-  {
-    public EnrichedAssetEventType Type { get; set; }
-
-    public string Id { get; set; }
-
-    public DateTimeOffset Created { get; set; }
-
-    public DateTimeOffset LastModified { get; set; }
-
-    public string CreatedBy { get; set; }
-
-    public string LastModifiedBy { get; set; }
-
-    public string MimeType { get; set; }
-
-    public string FileName { get; set; }
-
-    public long FileVersion { get; set; }
-
-    public long FileSize { get; set; }
-
-    public int? PixelWidth { get; set; }
-
-    public int? PixelHeight { get; set; }
-
-    public AssetType AssetType { get; set; }
-
-    public bool IsImage { get; set; }
-
-    public override long Partition { get; set; }
-
-    public string CreatedById
+    /// <summary>
+    /// Event on an asset.
+    /// </summary>
+    public sealed class EnrichedAssetEvent : EnrichedUserEventBase, IEnrichedEntityEvent
     {
-      get
-      {
-        return CreatedBy == null ? null : CreatedBy.Contains(":") ? CreatedBy.Split(':')[1] : null;
-      }
-    }
+        /// <summary>
+        /// Type of the event.
+        /// </summary>
+        public EnrichedAssetEventType Type { get; set; }
 
-    public string CreatedByType
-    {
-      get
-      {
-        return CreatedBy == null ? null : CreatedBy.Contains(":") ? CreatedBy.Split(':')[0] : null;
-      }
-    }
+        /// <summary>
+        /// Asset's id.
+        /// </summary>
+        public string Id { get; set; }
 
-    public string LastModifiedById
-    {
-      get
-      {
-        return LastModifiedBy == null ? null : LastModifiedBy.Contains(":") ? LastModifiedBy.Split(':')[1] : null;
-      }
-    }
+        /// <summary>
+        /// When the asset has been created.
+        /// </summary>
+        public DateTimeOffset Created { get; set; }
 
-    public string LastModifiedByType
-    {
-      get
-      {
-        return LastModifiedBy == null ? null : LastModifiedBy.Contains(":") ? LastModifiedBy.Split(':')[0] : null;
-      }
+        /// <summary>
+        /// When the asset has been modified.
+        /// </summary>
+        public DateTimeOffset LastModified { get; set; }
+
+        /// <summary>
+        /// Who has created the asset.
+        /// </summary>
+        public Actor CreatedBy { get; set; }
+
+        /// <summary>
+        /// Who has modified the asset.
+        /// </summary>
+        public Actor LastModifiedBy { get; set; }
+
+        /// <summary>
+        /// Mime type of the asset.
+        /// </summary>
+        public string MimeType { get; set; }
+
+        /// <summary>
+        /// File name of the asset.
+        /// </summary>
+        public string FileName { get; set; }
+
+        /// <summary>
+        /// Version of the asset.
+        /// </summary>
+        public long FileVersion { get; set; }
+
+        /// <summary>
+        /// Size of the asset.
+        /// </summary>
+        public long FileSize { get; set; }
+
+        /// <summary>
+        /// Width in pixel if the asset is an image.
+        /// </summary>
+        public int? PixelWidth { get; set; }
+
+        /// <summary>
+        /// Height in pixel if the asset is an image.
+        /// </summary>
+        public int? PixelHeight { get; set; }
+
+        /// <summary>
+        /// Type of the asset.
+        /// </summary>
+        public AssetType AssetType { get; set; }
+
+        /// <summary>
+        /// Is an image.
+        /// </summary>
+        [JsonIgnore]
+        public bool IsImage
+        {
+            get { return AssetType == AssetType.Image; }
+        }
     }
-  }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedAssetEventType.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedAssetEventType.cs
@@ -1,0 +1,17 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+namespace Squidex.ClientLibrary.EnrichedEvents
+{
+  public enum EnrichedAssetEventType
+  {
+    Created,
+    Deleted,
+    Annotated,
+    Updated
+  }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedCommentEvent.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedCommentEvent.cs
@@ -9,12 +9,19 @@ using System;
 
 namespace Squidex.ClientLibrary.EnrichedEvents
 {
-  public sealed class EnrichedCommentEvent : EnrichedUserEventBase
-  {
-    public string Text { get; set; }
+    /// <summary>
+    /// Event generated from a comment.
+    /// </summary>
+    public sealed class EnrichedCommentEvent : EnrichedUserEventBase
+    {
+        /// <summary>
+        /// Comment's text.
+        /// </summary>
+        public string Text { get; set; }
 
-    public Uri Url { get; set; }
-
-    public override long Partition { get; set; }
-  }
+        /// <summary>
+        /// Url of the content commented.
+        /// </summary>
+        public Uri Url { get; set; }
+    }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedCommentEvent.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedCommentEvent.cs
@@ -1,0 +1,20 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System;
+
+namespace Squidex.ClientLibrary.EnrichedEvents
+{
+  public sealed class EnrichedCommentEvent : EnrichedUserEventBase
+  {
+    public string Text { get; set; }
+
+    public Uri Url { get; set; }
+
+    public override long Partition { get; set; }
+  }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedContentEvent.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedContentEvent.cs
@@ -1,0 +1,106 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Squidex.ClientLibrary.EnrichedEvents
+{
+  public sealed class EnrichedContentEvent<T> : EnrichedContentEvent
+  {
+    public new T Data { get; set; }
+
+    public new T DataOld { get; set; }
+  }
+
+  public class EnrichedContentEvent : EnrichedSchemaEventBase, IEnrichedEntityEvent
+  {
+    public EnrichedContentEventType Type { get; set; }
+
+    public string Id { get; set; }
+
+    public DateTimeOffset Created { get; set; }
+
+    public DateTimeOffset LastModified { get; set; }
+
+    public string CreatedBy { get; set; }
+
+    public string LastModifiedBy { get; set; }
+
+    public JObject Data { get; set; }
+
+    public JObject DataOld { get; set; }
+
+    public Status Status { get; set; }
+
+    public override long Partition { get; set; }
+
+    public string CreatedById
+    {
+      get
+      {
+        return CreatedBy == null ? null : CreatedBy.Contains(":") ? CreatedBy.Split(':')[1] : null;
+      }
+    }
+
+    public string CreatedByType
+    {
+      get
+      {
+        return CreatedBy == null ? null : CreatedBy.Contains(":") ? CreatedBy.Split(':')[0] : null;
+      }
+    }
+
+    public string LastModifiedById
+    {
+      get
+      {
+        return LastModifiedBy == null ? null : LastModifiedBy.Contains(":") ? LastModifiedBy.Split(':')[1] : null;
+      }
+    }
+
+    public string LastModifiedByType
+    {
+      get
+      {
+        return LastModifiedBy == null ? null : LastModifiedBy.Contains(":") ? LastModifiedBy.Split(':')[0] : null;
+      }
+    }
+
+    public EnrichedContentEvent<T> ToTypedContent<T>()
+    {
+      var contentType = typeof(T);
+
+      if (contentType == null)
+      {
+        throw new ArgumentNullException(nameof(contentType));
+      }
+
+      var typedEvent = typeof(EnrichedContentEvent<>).MakeGenericType(contentType);
+
+      var obj = (EnrichedContentEvent<T>)Activator.CreateInstance(typedEvent);
+
+      foreach (var property in typeof(EnrichedContentEvent).GetProperties().Where(prop => prop.CanWrite))
+      {
+        property.SetValue(obj, property.GetValue(this));
+      }
+
+      if (this.Data != null)
+      {
+        obj.Data = (T)this.Data.ToObject(contentType);
+      }
+
+      if (this.DataOld != null)
+      {
+        obj.DataOld = (T)this.DataOld.ToObject(contentType);
+      }
+
+      return obj;
+    }
+  }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedContentEvent.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedContentEvent.cs
@@ -72,7 +72,7 @@ namespace Squidex.ClientLibrary.EnrichedEvents
       }
     }
 
-    public EnrichedContentEvent<T> ToTypedContent<T>()
+    public EnrichedContentEvent<T> ToTyped<T>()
     {
       var contentType = typeof(T);
 

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedContentEvent.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedContentEvent.cs
@@ -7,100 +7,112 @@
 
 using System;
 using System.Linq;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Squidex.ClientLibrary.Utils;
 
 namespace Squidex.ClientLibrary.EnrichedEvents
 {
-  public sealed class EnrichedContentEvent<T> : EnrichedContentEvent
-  {
-    public new T Data { get; set; }
-
-    public new T DataOld { get; set; }
-  }
-
-  public class EnrichedContentEvent : EnrichedSchemaEventBase, IEnrichedEntityEvent
-  {
-    public EnrichedContentEventType Type { get; set; }
-
-    public string Id { get; set; }
-
-    public DateTimeOffset Created { get; set; }
-
-    public DateTimeOffset LastModified { get; set; }
-
-    public string CreatedBy { get; set; }
-
-    public string LastModifiedBy { get; set; }
-
-    public JObject Data { get; set; }
-
-    public JObject DataOld { get; set; }
-
-    public Status Status { get; set; }
-
-    public override long Partition { get; set; }
-
-    public string CreatedById
+    /// <inheritdoc />
+    public sealed class EnrichedContentEvent<T> : EnrichedContentEvent
     {
-      get
-      {
-        return CreatedBy == null ? null : CreatedBy.Contains(":") ? CreatedBy.Split(':')[1] : null;
-      }
+        /// <summary>
+        /// Data payload (updated).
+        /// </summary>
+        public new T Data { get; set; }
+
+        /// <summary>
+        /// Data payload (previous).
+        /// </summary>
+        public new T DataOld { get; set; }
     }
 
-    public string CreatedByType
+    /// <summary>
+    /// Event on a content.
+    /// </summary>
+    public class EnrichedContentEvent : EnrichedSchemaEventBase, IEnrichedEntityEvent
     {
-      get
-      {
-        return CreatedBy == null ? null : CreatedBy.Contains(":") ? CreatedBy.Split(':')[0] : null;
-      }
+        /// <summary>
+        /// Content event type.
+        /// </summary>
+        public EnrichedContentEventType Type { get; set; }
+
+        /// <summary>
+        /// Content id.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// When the content has been created.
+        /// </summary>
+        public DateTimeOffset Created { get; set; }
+
+        /// <summary>
+        /// When the content has been modified.
+        /// </summary>
+        public DateTimeOffset LastModified { get; set; }
+
+        /// <summary>
+        /// Who has created the content.
+        /// </summary>
+        [JsonConverter(typeof(ActorConverter))]
+        public Actor CreatedBy { get; set; }
+
+        /// <summary>
+        /// Who has modified the content.
+        /// </summary>
+        [JsonConverter(typeof(ActorConverter))]
+        public Actor LastModifiedBy { get; set; }
+
+        /// <summary>
+        /// Data payload (updated).
+        /// </summary>
+        public JObject Data { get; set; }
+
+        /// <summary>
+        /// Data payload (previous).
+        /// </summary>
+        public JObject DataOld { get; set; }
+
+        /// <summary>
+        /// Status of the content.
+        /// </summary>
+        public Status Status { get; set; }
+
+        /// <summary>
+        /// Get a instance of EnrichedContentEvent where Data and DataOld have type T.
+        /// </summary>
+        /// <typeparam name="T">Type of Data and DataOld properties.</typeparam>
+        /// <returns>EnrichedContentEvent instance where Data and DataOld have type T.</returns>
+        public EnrichedContentEvent<T> ToTyped<T>()
+        {
+            var contentType = typeof(T);
+
+            if (contentType == null)
+            {
+                throw new ArgumentNullException(nameof(contentType));
+            }
+
+            var typedEvent = typeof(EnrichedContentEvent<>).MakeGenericType(contentType);
+
+            var obj = (EnrichedContentEvent<T>)Activator.CreateInstance(typedEvent);
+
+            foreach (var property in typeof(EnrichedContentEvent).GetProperties().Where(prop => prop.CanWrite))
+            {
+                property.SetValue(obj, property.GetValue(this));
+            }
+
+            if (this.Data != null)
+            {
+                obj.Data = (T)this.Data.ToObject(contentType);
+            }
+
+            if (this.DataOld != null)
+            {
+                obj.DataOld = (T)this.DataOld.ToObject(contentType);
+            }
+
+            return obj;
+        }
     }
-
-    public string LastModifiedById
-    {
-      get
-      {
-        return LastModifiedBy == null ? null : LastModifiedBy.Contains(":") ? LastModifiedBy.Split(':')[1] : null;
-      }
-    }
-
-    public string LastModifiedByType
-    {
-      get
-      {
-        return LastModifiedBy == null ? null : LastModifiedBy.Contains(":") ? LastModifiedBy.Split(':')[0] : null;
-      }
-    }
-
-    public EnrichedContentEvent<T> ToTyped<T>()
-    {
-      var contentType = typeof(T);
-
-      if (contentType == null)
-      {
-        throw new ArgumentNullException(nameof(contentType));
-      }
-
-      var typedEvent = typeof(EnrichedContentEvent<>).MakeGenericType(contentType);
-
-      var obj = (EnrichedContentEvent<T>)Activator.CreateInstance(typedEvent);
-
-      foreach (var property in typeof(EnrichedContentEvent).GetProperties().Where(prop => prop.CanWrite))
-      {
-        property.SetValue(obj, property.GetValue(this));
-      }
-
-      if (this.Data != null)
-      {
-        obj.Data = (T)this.Data.ToObject(contentType);
-      }
-
-      if (this.DataOld != null)
-      {
-        obj.DataOld = (T)this.DataOld.ToObject(contentType);
-      }
-
-      return obj;
-    }
-  }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedContentEventType.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedContentEventType.cs
@@ -7,13 +7,39 @@
 
 namespace Squidex.ClientLibrary.EnrichedEvents
 {
-  public enum EnrichedContentEventType
-  {
-    Created,
-    Deleted,
-    Published,
-    StatusChanged,
-    Updated,
-    Unpublished
-  }
+    /// <summary>
+    /// Type of event on a content.
+    /// </summary>
+    public enum EnrichedContentEventType
+    {
+        /// <summary>
+        /// Content Created.
+        /// </summary>
+        Created,
+
+        /// <summary>
+        /// Content Deleted.
+        /// </summary>
+        Deleted,
+
+        /// <summary>
+        /// Content Published.
+        /// </summary>
+        Published,
+
+        /// <summary>
+        /// Content Status Changed.
+        /// </summary>
+        StatusChanged,
+
+        /// <summary>
+        /// Content Updated.
+        /// </summary>
+        Updated,
+
+        /// <summary>
+        /// Content Unpublished.
+        /// </summary>
+        Unpublished
+    }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedContentEventType.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedContentEventType.cs
@@ -1,0 +1,19 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+namespace Squidex.ClientLibrary.EnrichedEvents
+{
+  public enum EnrichedContentEventType
+  {
+    Created,
+    Deleted,
+    Published,
+    StatusChanged,
+    Updated,
+    Unpublished
+  }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedEvent.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedEvent.cs
@@ -1,0 +1,39 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System;
+
+namespace Squidex.ClientLibrary.EnrichedEvents
+{
+  public abstract class EnrichedEvent
+  {
+    public string AppId { get; set; }
+
+    public DateTimeOffset Timestamp { get; set; }
+
+    public string Name { get; set; }
+
+    public long Version { get; set; }
+
+    public abstract long Partition { get; set; }
+    public string AppName
+    {
+      get
+      {
+        return AppId == null ? null : AppId.Contains(",") ? AppId.Split(',')[1] : null;
+      }
+    }
+
+    public Guid AppGuid
+    {
+      get
+      {
+        return AppId == null ? default : AppId.Contains(",") ? Guid.Parse(AppId.Split(',')[0]) : default;
+      }
+    }
+  }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedEvent.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedEvent.cs
@@ -6,34 +6,36 @@
 // ==========================================================================
 
 using System;
+using Newtonsoft.Json;
+using Squidex.ClientLibrary.Utils;
 
 namespace Squidex.ClientLibrary.EnrichedEvents
 {
-  public abstract class EnrichedEvent
-  {
-    public string AppId { get; set; }
-
-    public DateTimeOffset Timestamp { get; set; }
-
-    public string Name { get; set; }
-
-    public long Version { get; set; }
-
-    public abstract long Partition { get; set; }
-    public string AppName
+    /// <summary>
+    /// Abstract class for the events sent by the rules.
+    /// </summary>
+    public abstract class EnrichedEvent
     {
-      get
-      {
-        return AppId == null ? null : AppId.Contains(",") ? AppId.Split(',')[1] : null;
-      }
-    }
+        /// <summary>
+        /// Application that generated the event.
+        /// </summary>
+        [JsonConverter(typeof(NamedIdConverter))]
+        [JsonProperty("appId")]
+        public NamedId App { get; set; }
 
-    public Guid AppGuid
-    {
-      get
-      {
-        return AppId == null ? default : AppId.Contains(",") ? Guid.Parse(AppId.Split(',')[0]) : default;
-      }
+        /// <summary>
+        /// When the event has been generated.
+        /// </summary>
+        public DateTimeOffset Timestamp { get; set; }
+
+        /// <summary>
+        /// Name of the event.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Version of the object.
+        /// </summary>
+        public long Version { get; set; }
     }
-  }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedEventEnvelope.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedEventEnvelope.cs
@@ -6,13 +6,47 @@
 // ==========================================================================
 
 using System;
+using Newtonsoft.Json;
 
 namespace Squidex.ClientLibrary.EnrichedEvents
 {
-  public class EnrichedEventEnvelope
-  {
-    public string Type { get; set; }
-    public DateTimeOffset Timestamp { get; set; }
-    public EnrichedEvent Payload { get; set; }
-  }
+    /// <summary>
+    /// Envelope which contains the generated events.
+    /// </summary>
+    public class EnrichedEventEnvelope
+    {
+        /// <summary>
+        /// Type of the event.
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// When the event has been generated.
+        /// </summary>
+        public DateTimeOffset Timestamp { get; set; }
+
+        /// <summary>
+        /// The payload of the evnet.
+        /// </summary>
+        public EnrichedEvent Payload { get; set; }
+
+        /// <summary>
+        /// Utils to deserialize an Envelope.
+        /// It uses TypeNameHandling = TypeNameHandling.Objects and SerializationBinder = new EnrichedEventSerializationBinder().
+        /// </summary>
+        /// <param name="json">The string to be deserialized.</param>
+        /// <param name="settings">Custom JsonSerializerSettings settings. TypeNameHandling and SerializationBinder will be overwritten.</param>
+        public static EnrichedEventEnvelope DeserializeEnvelope(string json, JsonSerializerSettings settings = null)
+        {
+            if (settings == null)
+            {
+                settings = new JsonSerializerSettings();
+            }
+
+            settings.TypeNameHandling = TypeNameHandling.Objects;
+            settings.SerializationBinder = new EnrichedEventSerializationBinder();
+
+            return JsonConvert.DeserializeObject<EnrichedEventEnvelope>(json, settings);
+        }
+    }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedEventEnvelope.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedEventEnvelope.cs
@@ -1,0 +1,18 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System;
+
+namespace Squidex.ClientLibrary.EnrichedEvents
+{
+  public class EnrichedEventEnvelope
+  {
+    public string Type { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
+    public EnrichedEvent Payload { get; set; }
+  }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedEventSerializationBinder.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedEventSerializationBinder.cs
@@ -12,26 +12,35 @@ using Newtonsoft.Json.Serialization;
 
 namespace Squidex.ClientLibrary.EnrichedEvents
 {
-  public sealed class EnrichedEventSerializationBinder : ISerializationBinder
-  {
-    public IList<Type> EnrichedEventTypes { get; set; } = new List<Type> {
-      typeof(EnrichedCommentEvent),
-      typeof(EnrichedContentEvent),
-      typeof(EnrichedManualEvent),
-      typeof(EnrichedAssetEvent),
-      typeof(EnrichedSchemaEvent),
-      typeof(EnrichedUsageExceededEvent)
-    };
-
-    public Type BindToType(string assemblyName, string typeName)
+    /// <summary>
+    /// Binder to deserialize the EnrichedEventEnvelope with the right payload using the $type on the json tree.
+    /// </summary>
+    public sealed class EnrichedEventSerializationBinder : ISerializationBinder
     {
-      return EnrichedEventTypes.SingleOrDefault(t => t.Name == typeName);
-    }
+        /// <summary>
+        /// List of available event classes.
+        /// </summary>
+        public IList<Type> EnrichedEventTypes { get; set; } = new List<Type>
+        {
+          typeof(EnrichedCommentEvent),
+          typeof(EnrichedContentEvent),
+          typeof(EnrichedManualEvent),
+          typeof(EnrichedAssetEvent),
+          typeof(EnrichedSchemaEvent),
+          typeof(EnrichedUsageExceededEvent)
+        };
 
-    public void BindToName(Type serializedType, out string assemblyName, out string typeName)
-    {
-      assemblyName = null;
-      typeName = serializedType.Name;
+        /// <inheritdoc/>
+        public Type BindToType(string assemblyName, string typeName)
+        {
+            return EnrichedEventTypes.SingleOrDefault(t => t.Name == typeName);
+        }
+
+        /// <inheritdoc/>
+        public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        {
+            assemblyName = null;
+            typeName = serializedType.Name;
+        }
     }
-  }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedEventSerializationBinder.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedEventSerializationBinder.cs
@@ -1,0 +1,37 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Serialization;
+
+namespace Squidex.ClientLibrary.EnrichedEvents
+{
+  public sealed class EnrichedEventSerializationBinder : ISerializationBinder
+  {
+    public IList<Type> EnrichedEventTypes { get; set; } = new List<Type> {
+      typeof(EnrichedCommentEvent),
+      typeof(EnrichedContentEvent),
+      typeof(EnrichedManualEvent),
+      typeof(EnrichedAssetEvent),
+      typeof(EnrichedSchemaEvent),
+      typeof(EnrichedUsageExceededEvent)
+    };
+
+    public Type BindToType(string assemblyName, string typeName)
+    {
+      return EnrichedEventTypes.SingleOrDefault(t => t.Name == typeName);
+    }
+
+    public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+    {
+      assemblyName = null;
+      typeName = serializedType.Name;
+    }
+  }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedManualEvent.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedManualEvent.cs
@@ -7,8 +7,10 @@
 
 namespace Squidex.ClientLibrary.EnrichedEvents
 {
-  public sealed class EnrichedManualEvent : EnrichedUserEventBase
-  {
-    public override long Partition { get; set; }
-  }
+    /// <summary>
+    /// Event triggered manually.
+    /// </summary>
+    public sealed class EnrichedManualEvent : EnrichedUserEventBase
+    {
+    }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedManualEvent.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedManualEvent.cs
@@ -1,0 +1,14 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+namespace Squidex.ClientLibrary.EnrichedEvents
+{
+  public sealed class EnrichedManualEvent : EnrichedUserEventBase
+  {
+    public override long Partition { get; set; }
+  }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedSchemaEvent.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedSchemaEvent.cs
@@ -7,12 +7,19 @@
 
 namespace Squidex.ClientLibrary.EnrichedEvents
 {
-  public sealed class EnrichedSchemaEvent : EnrichedSchemaEventBase, IEnrichedEntityEvent
-  {
-    public EnrichedSchemaEventType Type { get; set; }
+    /// <summary>
+    /// Event on a schema.
+    /// </summary>
+    public sealed class EnrichedSchemaEvent : EnrichedSchemaEventBase, IEnrichedEntityEvent
+    {
+        /// <summary>
+        /// Type of the event.
+        /// </summary>
+        public EnrichedSchemaEventType Type { get; set; }
 
-    public string Id { get; set; }
-
-    public override long Partition { get; set; }
-  }
+        /// <summary>
+        /// Schema id.
+        /// </summary>
+        public string Id { get; set; }
+    }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedSchemaEvent.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedSchemaEvent.cs
@@ -1,0 +1,18 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+namespace Squidex.ClientLibrary.EnrichedEvents
+{
+  public sealed class EnrichedSchemaEvent : EnrichedSchemaEventBase, IEnrichedEntityEvent
+  {
+    public EnrichedSchemaEventType Type { get; set; }
+
+    public string Id { get; set; }
+
+    public override long Partition { get; set; }
+  }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedSchemaEventBase.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedSchemaEventBase.cs
@@ -5,27 +5,21 @@
 //  All rights reserved. Licensed under the MIT license.
 // ==========================================================================
 
-using System;
+using Newtonsoft.Json;
+using Squidex.ClientLibrary.Utils;
 
 namespace Squidex.ClientLibrary.EnrichedEvents
 {
-  public abstract class EnrichedSchemaEventBase : EnrichedUserEventBase
-  {
-    public string SchemaId { get; set; }
-    public string SchemaName
+    /// <summary>
+    /// Abstract class for events on a schema.
+    /// </summary>
+    public abstract class EnrichedSchemaEventBase : EnrichedUserEventBase
     {
-      get
-      {
-        return SchemaId == null ? null : SchemaId.Contains(",") ? SchemaId.Split(',')[1] : null;
-      }
+        /// <summary>
+        /// Schema changed.
+        /// </summary>
+        [JsonConverter(typeof(NamedIdConverter))]
+        [JsonProperty("schemaId")]
+        public NamedId Schema { get; set; }
     }
-
-    public Guid SchemaGuid
-    {
-      get
-      {
-        return SchemaId == null ? default : SchemaId.Contains(",") ? Guid.Parse(SchemaId.Split(',')[0]) : default;
-      }
-    }
-  }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedSchemaEventBase.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedSchemaEventBase.cs
@@ -1,0 +1,31 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System;
+
+namespace Squidex.ClientLibrary.EnrichedEvents
+{
+  public abstract class EnrichedSchemaEventBase : EnrichedUserEventBase
+  {
+    public string SchemaId { get; set; }
+    public string SchemaName
+    {
+      get
+      {
+        return SchemaId == null ? null : SchemaId.Contains(",") ? SchemaId.Split(',')[1] : null;
+      }
+    }
+
+    public Guid SchemaGuid
+    {
+      get
+      {
+        return SchemaId == null ? default : SchemaId.Contains(",") ? Guid.Parse(SchemaId.Split(',')[0]) : default;
+      }
+    }
+  }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedSchemaEventType.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedSchemaEventType.cs
@@ -1,0 +1,18 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+namespace Squidex.ClientLibrary.EnrichedEvents
+{
+  public enum EnrichedSchemaEventType
+  {
+    Created,
+    Deleted,
+    Published,
+    Unpublished,
+    Updated
+  }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedSchemaEventType.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedSchemaEventType.cs
@@ -7,12 +7,34 @@
 
 namespace Squidex.ClientLibrary.EnrichedEvents
 {
-  public enum EnrichedSchemaEventType
-  {
-    Created,
-    Deleted,
-    Published,
-    Unpublished,
-    Updated
-  }
+    /// <summary>
+    /// Schema event types.
+    /// </summary>
+    public enum EnrichedSchemaEventType
+    {
+        /// <summary>
+        /// Schema created.
+        /// </summary>
+        Created,
+
+        /// <summary>
+        /// Schema Deleted.
+        /// </summary>
+        Deleted,
+
+        /// <summary>
+        /// Schema Published.
+        /// </summary>
+        Published,
+
+        /// <summary>
+        /// Schema Unpublished.
+        /// </summary>
+        Unpublished,
+
+        /// <summary>
+        /// Schema updated.
+        /// </summary>
+        Updated
+    }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedUsageExceededEvent.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedUsageExceededEvent.cs
@@ -1,0 +1,18 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+namespace Squidex.ClientLibrary.EnrichedEvents
+{
+  public sealed class EnrichedUsageExceededEvent : EnrichedEvent
+  {
+    public long CallsCurrent { get; set; }
+
+    public long CallsLimit { get; set; }
+
+    public override long Partition { get; set; }
+  }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedUsageExceededEvent.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedUsageExceededEvent.cs
@@ -7,12 +7,19 @@
 
 namespace Squidex.ClientLibrary.EnrichedEvents
 {
-  public sealed class EnrichedUsageExceededEvent : EnrichedEvent
-  {
-    public long CallsCurrent { get; set; }
+    /// <summary>
+    /// Usage Exceeded Event.
+    /// </summary>
+    public sealed class EnrichedUsageExceededEvent : EnrichedEvent
+    {
+        /// <summary>
+        /// Current calls.
+        /// </summary>
+        public long CallsCurrent { get; set; }
 
-    public long CallsLimit { get; set; }
-
-    public override long Partition { get; set; }
-  }
+        /// <summary>
+        /// Calls limit.
+        /// </summary>
+        public long CallsLimit { get; set; }
+    }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedUserEventBase.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedUserEventBase.cs
@@ -5,26 +5,20 @@
 //  All rights reserved. Licensed under the MIT license.
 // ==========================================================================
 
+using Newtonsoft.Json;
+using Squidex.ClientLibrary.Utils;
+
 namespace Squidex.ClientLibrary.EnrichedEvents
 {
-  public abstract class EnrichedUserEventBase : EnrichedEvent
-  {
-    public string Actor { get; set; }
-
-    public string ActorId
+    /// <summary>
+    /// Avstract class for events triggered by an Actor.
+    /// </summary>
+    public abstract class EnrichedUserEventBase : EnrichedEvent
     {
-      get
-      {
-        return Actor == null ? null : Actor.Contains(":") ? Actor.Split(':')[1] : null;
-      }
+        /// <summary>
+        /// Actor who has triggered the event.
+        /// </summary>
+        [JsonConverter(typeof(ActorConverter))]
+        public Actor Actor { get; set; }
     }
-
-    public string ActorType
-    {
-      get
-      {
-        return Actor == null ? null : Actor.Contains(":") ? Actor.Split(':')[0] : null;
-      }
-    }
-  }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedUserEventBase.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/EnrichedUserEventBase.cs
@@ -1,0 +1,30 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+namespace Squidex.ClientLibrary.EnrichedEvents
+{
+  public abstract class EnrichedUserEventBase : EnrichedEvent
+  {
+    public string Actor { get; set; }
+
+    public string ActorId
+    {
+      get
+      {
+        return Actor == null ? null : Actor.Contains(":") ? Actor.Split(':')[1] : null;
+      }
+    }
+
+    public string ActorType
+    {
+      get
+      {
+        return Actor == null ? null : Actor.Contains(":") ? Actor.Split(':')[0] : null;
+      }
+    }
+  }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/IEnrichedEntityEvent.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/IEnrichedEntityEvent.cs
@@ -1,0 +1,14 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+namespace Squidex.ClientLibrary.EnrichedEvents
+{
+  public interface IEnrichedEntityEvent
+  {
+    string Id { get; }
+  }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/IEnrichedEntityEvent.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/EnrichedEvents/IEnrichedEntityEvent.cs
@@ -7,8 +7,14 @@
 
 namespace Squidex.ClientLibrary.EnrichedEvents
 {
-  public interface IEnrichedEntityEvent
-  {
-    string Id { get; }
-  }
+    /// <summary>
+    /// Interface IEnrichedEntityEvent.
+    /// </summary>
+    public interface IEnrichedEntityEvent
+    {
+        /// <summary>
+        /// Id.
+        /// </summary>
+        string Id { get; }
+    }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/Status.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/Status.cs
@@ -10,58 +10,94 @@ using System.ComponentModel;
 
 namespace Squidex.ClientLibrary
 {
-  [TypeConverter(typeof(StatusTypeConverter))]
-  public readonly struct Status : IEquatable<Status>, IComparable<Status>
-  {
-    public static readonly Status Archived = new Status("Archived");
-    public static readonly Status Draft = new Status("Draft");
-    public static readonly Status Published = new Status("Published");
-
-    private readonly string name;
-
-    public string Name
+    /// <summary>
+    /// Default status strings.
+    /// </summary>
+    [TypeConverter(typeof(StatusTypeConverter))]
+    public readonly struct Status : IEquatable<Status>, IComparable<Status>
     {
-      get { return name ?? "Unknown"; }
-    }
+        /// <summary>
+        /// Content is Archived (soft-delete).
+        /// </summary>
+        public static readonly Status Archived = new Status("Archived");
 
-    public Status(string name)
-    {
-      this.name = name;
-    }
+        /// <summary>
+        /// Content is not ready and not available in the API by default.
+        /// </summary>
+        public static readonly Status Draft = new Status("Draft");
 
-    public override bool Equals(object obj)
-    {
-      return obj is Status status && Equals(status);
-    }
+        /// <summary>
+        /// Content is ready and published.
+        /// </summary>
+        public static readonly Status Published = new Status("Published");
 
-    public bool Equals(Status other)
-    {
-      return string.Equals(Name, other.Name);
-    }
+        private readonly string name;
 
-    public override int GetHashCode()
-    {
-      return Name.GetHashCode();
-    }
+        /// <summary>
+        /// Name of the status.
+        /// </summary>
+        public string Name
+        {
+            get { return name ?? "Unknown"; }
+        }
 
-    public override string ToString()
-    {
-      return Name;
-    }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Status"/> struct.
+        /// </summary>
+        /// <param name="name">Status name.</param>
+        public Status(string name)
+        {
+            this.name = name;
+        }
 
-    public int CompareTo(Status other)
-    {
-      return string.Compare(Name, other.Name, StringComparison.Ordinal);
-    }
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            return obj is Status status && Equals(status);
+        }
 
-    public static bool operator ==(Status lhs, Status rhs)
-    {
-      return lhs.Equals(rhs);
-    }
+        /// <inheritdoc />
+        public bool Equals(Status other)
+        {
+            return string.Equals(Name, other.Name);
+        }
 
-    public static bool operator !=(Status lhs, Status rhs)
-    {
-      return !lhs.Equals(rhs);
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return Name.GetHashCode();
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return Name;
+        }
+
+        /// <inheritdoc />
+        public int CompareTo(Status other)
+        {
+            return string.Compare(Name, other.Name, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Equals operator.
+        /// </summary>
+        /// <param name="lhs">Left.</param>
+        /// <param name="rhs">Right.</param>
+        public static bool operator ==(Status lhs, Status rhs)
+        {
+            return lhs.Equals(rhs);
+        }
+
+        /// <summary>
+        /// Not equals operator.
+        /// </summary>
+        /// <param name="lhs">Left.</param>
+        /// <param name="rhs">Right.</param>
+        public static bool operator !=(Status lhs, Status rhs)
+        {
+            return !lhs.Equals(rhs);
+        }
     }
-  }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/Status.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/Status.cs
@@ -5,26 +5,63 @@
 //  All rights reserved. Licensed under the MIT license.
 // ==========================================================================
 
+using System;
+using System.ComponentModel;
+
 namespace Squidex.ClientLibrary
 {
-    /// <summary>
-    /// Default status strings.
-    /// </summary>
-    public static class Status
+  [TypeConverter(typeof(StatusTypeConverter))]
+  public readonly struct Status : IEquatable<Status>, IComparable<Status>
+  {
+    public static readonly Status Archived = new Status("Archived");
+    public static readonly Status Draft = new Status("Draft");
+    public static readonly Status Published = new Status("Published");
+
+    private readonly string name;
+
+    public string Name
     {
-        /// <summary>
-        /// Content is Archived (soft-delete).
-        /// </summary>
-        public const string Archived = "Archived";
-
-        /// <summary>
-        /// Content is not ready and not available in the API by default.
-        /// </summary>
-        public const string Draft = "Draft";
-
-        /// <summary>
-        /// Content is ready and published.
-        /// </summary>
-        public const string Published = "Published";
+      get { return name ?? "Unknown"; }
     }
+
+    public Status(string name)
+    {
+      this.name = name;
+    }
+
+    public override bool Equals(object obj)
+    {
+      return obj is Status status && Equals(status);
+    }
+
+    public bool Equals(Status other)
+    {
+      return string.Equals(Name, other.Name);
+    }
+
+    public override int GetHashCode()
+    {
+      return Name.GetHashCode();
+    }
+
+    public override string ToString()
+    {
+      return Name;
+    }
+
+    public int CompareTo(Status other)
+    {
+      return string.Compare(Name, other.Name, StringComparison.Ordinal);
+    }
+
+    public static bool operator ==(Status lhs, Status rhs)
+    {
+      return lhs.Equals(rhs);
+    }
+
+    public static bool operator !=(Status lhs, Status rhs)
+    {
+      return !lhs.Equals(rhs);
+    }
+  }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/StatusTypeConverter.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/StatusTypeConverter.cs
@@ -1,0 +1,41 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace Squidex.ClientLibrary
+{
+  public sealed class StatusTypeConverter : TypeConverter
+  {
+    public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+    {
+      return sourceType == typeof(string);
+    }
+
+    public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+    {
+      return destinationType == typeof(string);
+    }
+
+    public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+    {
+      if (value is string s)
+      {
+        return new Status(s);
+      }
+
+      return default(Status);
+    }
+
+    public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+    {
+      return value.ToString();
+    }
+  }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/StatusTypeConverter.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/StatusTypeConverter.cs
@@ -11,31 +11,38 @@ using System.Globalization;
 
 namespace Squidex.ClientLibrary
 {
-  public sealed class StatusTypeConverter : TypeConverter
-  {
-    public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+    /// <summary>
+    /// Converter for the Status.
+    /// </summary>
+    public sealed class StatusTypeConverter : TypeConverter
     {
-      return sourceType == typeof(string);
-    }
+        /// <inheritdoc />
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string);
+        }
 
-    public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-    {
-      return destinationType == typeof(string);
-    }
+        /// <inheritdoc />
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return destinationType == typeof(string);
+        }
 
-    public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
-    {
-      if (value is string s)
-      {
-        return new Status(s);
-      }
+        /// <inheritdoc />
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string s)
+            {
+                return new Status(s);
+            }
 
-      return default(Status);
-    }
+            return default(Status);
+        }
 
-    public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
-    {
-      return value.ToString();
+        /// <inheritdoc />
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            return value.ToString();
+        }
     }
-  }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/Utils/Actor.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/Utils/Actor.cs
@@ -5,31 +5,25 @@
 //  All rights reserved. Licensed under the MIT license.
 // ==========================================================================
 
-namespace Squidex.ClientLibrary.EnrichedEvents
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Squidex.ClientLibrary.Utils
 {
     /// <summary>
-    /// Type of events on an asset.
+    /// Represent an actor that make actions.
     /// </summary>
-    public enum EnrichedAssetEventType
+    public class Actor
     {
         /// <summary>
-        /// Asset Created.
+        /// Id.
         /// </summary>
-        Created,
+        public string Id { get; set; }
 
         /// <summary>
-        /// Asset Deleted.
+        /// Type.
         /// </summary>
-        Deleted,
-
-        /// <summary>
-        /// Asset Annotated.
-        /// </summary>
-        Annotated,
-
-        /// <summary>
-        /// Asset Updated.
-        /// </summary>
-        Updated
+        public string Type { get; set; }
     }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/Utils/ActorConverter.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/Utils/ActorConverter.cs
@@ -1,0 +1,52 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Squidex.ClientLibrary.Utils
+{
+    /// <summary>
+    /// Convert actor string
+    /// Example of input: "subject:123456789".
+    /// </summary>
+    public class ActorConverter : JsonConverter
+    {
+        /// <inheritdoc />
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Actor);
+        }
+
+        /// <inheritdoc />
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
+            var s = (reader.Value as string).Split(':');
+
+            return new Actor()
+            {
+                Id = s[1],
+                Type = s[0]
+            };
+        }
+
+        /// <inheritdoc />
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var actor = value as Actor;
+            serializer.Serialize(writer, $"{actor.Type}:{actor.Id}");
+        }
+    }
+}

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/Utils/NamedId.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/Utils/NamedId.cs
@@ -5,31 +5,25 @@
 //  All rights reserved. Licensed under the MIT license.
 // ==========================================================================
 
-namespace Squidex.ClientLibrary.EnrichedEvents
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Squidex.ClientLibrary.Utils
 {
     /// <summary>
-    /// Type of events on an asset.
+    /// Id with a name.
     /// </summary>
-    public enum EnrichedAssetEventType
+    public class NamedId
     {
         /// <summary>
-        /// Asset Created.
+        /// Id.
         /// </summary>
-        Created,
+        public string Id { get; set; }
 
         /// <summary>
-        /// Asset Deleted.
+        /// Name.
         /// </summary>
-        Deleted,
-
-        /// <summary>
-        /// Asset Annotated.
-        /// </summary>
-        Annotated,
-
-        /// <summary>
-        /// Asset Updated.
-        /// </summary>
-        Updated
+        public string Name { get; set; }
     }
 }

--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/Utils/NamedIdConverter.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/Utils/NamedIdConverter.cs
@@ -1,0 +1,52 @@
+﻿// ==========================================================================
+//  Squidex Headless CMS
+// ==========================================================================
+//  Copyright (c) Squidex UG (haftungsbeschraenkt)
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Squidex.ClientLibrary.Utils
+{
+    /// <summary>
+    /// Convert comma separated string to NamedId
+    /// Example of input: "00000000-0000-0000-0000-000000000000,name".
+    /// </summary>
+    public class NamedIdConverter : JsonConverter
+    {
+        /// <inheritdoc />
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(NamedId);
+        }
+
+        /// <inheritdoc />
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
+            var s = (reader.Value as string).Split(',');
+
+            return new NamedId()
+            {
+                Id = s[0],
+                Name = s[1]
+            };
+        }
+
+        /// <inheritdoc />
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var namedId = value as NamedId;
+            serializer.Serialize(writer, $"{namedId.Id},{namedId.Name}");
+        }
+    }
+}


### PR DESCRIPTION
Imported the EnrichedEvents models from the main codebase, adapted to avoid too many dependencies on other objects (RefToken, DomainId...) and keeping the compatibility with netstandard2.0 and C#7.3.

Added EnrichedEventEnvelope model (missing in the main codebase).

Added EnrichedEventSerializationBinder to deserialize the payload into the right class

The not generic ```EnrichedContentEvent``` uses ```JObject``` as type of the Data/DataOld properties. The method ```EnrichedContentEvent.ToTyped<T>()``` generates an instance of ```EnrichedContentEvent<T>``` where ```T``` is the type of the Data/DataOld properties (the same used on the other SDK methods). I'm not sure if this is the best solution to handle the custom types but it works fine.

Included a test class (EnrichedEventsTests) as usage example.
