### PR TITLE
Updated GraphQlGetAsync to be able to use CDN

### DIFF
--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/ContentsClient.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/ContentsClient.cs
@@ -99,7 +99,7 @@ namespace Squidex.ClientLibrary
 
             var query = BuildQuery(request);
 
-            var response = await RequestJsonAsync<GraphQlResponse<TResponse>>(HttpMethod.Get, BuildAppUrl("graphql", false, context) + query, null, context, ct);
+            var response = await RequestJsonAsync<GraphQlResponse<TResponse>>(HttpMethod.Get, BuildAppUrl("graphql", true, context) + query, null, context, ct);
 
             if (response.Errors?.Length > 0)
             {


### PR DESCRIPTION
Updates the `GraphQLGetAsync` method to use the CDN (if configured) by passing "true" to the `query` parameter when calling `BuildAppUrl`.

As per this conversation: https://support.squidex.io/t/cloud-downtime-degraded-performance/4341/3 there is no reason why `GraphQLGetAsync` shouldn't be able to use the CDN.