### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
         
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3.4.0
 
     - name: setup zip
-      uses: montudor/action-zip@v0.1.0
+      uses: montudor/action-zip@v1.0.0
  
     - name: setup dotnet
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v3.0.3
       with:
         dotnet-version: 7.0.x
 

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
         
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3.4.0
  
     - name: setup dotnet
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v3.0.3
       with:
         dotnet-version: 7.0.x
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[montudor/action-zip](https://github.com/montudor/action-zip)** published a new release **[v1.0.0](https://github.com/montudor/action-zip/releases/tag/v1.0.0)** on 2021-04-21T17:46:31Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.4.0](https://github.com/actions/checkout/releases/tag/v3.4.0)** on 2023-03-15T19:47:24Z
* **[actions/setup-dotnet](https://github.com/actions/setup-dotnet)** published a new release **[v3.0.3](https://github.com/actions/setup-dotnet/releases/tag/v3.0.3)** on 2022-10-27T13:09:53Z
