### PR TITLE
Add sync option for max-age of content/assets

### DIFF
--- a/cli/Squidex.CLI/Squidex.CLI.Core/Commands/Implementation/Sync/Assets/AssetsSynchronizer.cs
+++ b/cli/Squidex.CLI/Squidex.CLI.Core/Commands/Implementation/Sync/Assets/AssetsSynchronizer.cs
@@ -63,7 +63,7 @@ public sealed class AssetsSynchronizer : ISynchronizer
 
             await session.Client.Assets.GetAllAsync(async asset =>
             {
-                if (asset.Created > options.LookbackDate || asset.LastModified > options.LookbackDate)
+                if (asset.Created >= options.MaxAgeDate || asset.LastModified >= options.MaxAgeDate)
                 {
                     var model = asset.ToModel();
 

--- a/cli/Squidex.CLI/Squidex.CLI.Core/Commands/Implementation/Sync/Assets/AssetsSynchronizer.cs
+++ b/cli/Squidex.CLI/Squidex.CLI.Core/Commands/Implementation/Sync/Assets/AssetsSynchronizer.cs
@@ -63,24 +63,26 @@ public sealed class AssetsSynchronizer : ISynchronizer
 
             await session.Client.Assets.GetAllAsync(async asset =>
             {
-                if (asset.Created >= options.MaxAgeDate || asset.LastModified >= options.MaxAgeDate)
+                if (asset.LastModified < options.MaxAgeDate)
                 {
-                    var model = asset.ToModel();
-
-                    model.FolderPath = await sync.Folders.GetPathAsync(asset.ParentId);
-
-                    assets.Add(model);
-
-                    if (assets.Count > 50)
-                    {
-                        await SaveAsync();
-
-                        assets.Clear();
-                        assetBatch++;
-                    }
-
-                    await downloadPipeline.DownloadAsync(asset);
+                    return;
                 }
+
+                var model = asset.ToModel();
+
+                model.FolderPath = await sync.Folders.GetPathAsync(asset.ParentId);
+
+                assets.Add(model);
+
+                if (assets.Count > 50)
+                {
+                    await SaveAsync();
+
+                    assets.Clear();
+                    assetBatch++;
+                }
+
+                await downloadPipeline.DownloadAsync(asset);
             });
 
             if (assets.Count > 0)

--- a/cli/Squidex.CLI/Squidex.CLI.Core/Commands/Implementation/Sync/Contents/ContentsSynchronizer.cs
+++ b/cli/Squidex.CLI/Squidex.CLI.Core/Commands/Implementation/Sync/Contents/ContentsSynchronizer.cs
@@ -72,16 +72,19 @@ public sealed class ContentsSynchronizer : ISynchronizer
 
             await client.GetAllAsync(async content =>
             {
-                content.MapComponents(schemaMap);
-
-                contents.Add(content.ToModel(schema.Name));
-
-                if (contents.Count > 50)
+                if (content.Created > options.LookbackDate || content.LastModified > options.LookbackDate)
                 {
-                    await SaveAsync();
+                    content.MapComponents(schemaMap);
 
-                    contents.Clear();
-                    contentBatch++;
+                    contents.Add(content.ToModel(schema.Name));
+
+                    if (contents.Count > 50)
+                    {
+                        await SaveAsync();
+
+                        contents.Clear();
+                        contentBatch++;
+                    }
                 }
             }, context: context);
 

--- a/cli/Squidex.CLI/Squidex.CLI.Core/Commands/Implementation/Sync/Contents/ContentsSynchronizer.cs
+++ b/cli/Squidex.CLI/Squidex.CLI.Core/Commands/Implementation/Sync/Contents/ContentsSynchronizer.cs
@@ -72,19 +72,21 @@ public sealed class ContentsSynchronizer : ISynchronizer
 
             await client.GetAllAsync(async content =>
             {
-                if (content.Created >= options.MaxAgeDate || content.LastModified >= options.MaxAgeDate)
+                if (content.LastModified < options.MaxAgeDate)
                 {
-                    content.MapComponents(schemaMap);
+                    return;
+                }
 
-                    contents.Add(content.ToModel(schema.Name));
+                content.MapComponents(schemaMap);
 
-                    if (contents.Count > 50)
-                    {
-                        await SaveAsync();
+                contents.Add(content.ToModel(schema.Name));
 
-                        contents.Clear();
-                        contentBatch++;
-                    }
+                if (contents.Count > 50)
+                {
+                    await SaveAsync();
+
+                    contents.Clear();
+                    contentBatch++;
                 }
             }, context: context);
 

--- a/cli/Squidex.CLI/Squidex.CLI.Core/Commands/Implementation/Sync/Contents/ContentsSynchronizer.cs
+++ b/cli/Squidex.CLI/Squidex.CLI.Core/Commands/Implementation/Sync/Contents/ContentsSynchronizer.cs
@@ -72,7 +72,7 @@ public sealed class ContentsSynchronizer : ISynchronizer
 
             await client.GetAllAsync(async content =>
             {
-                if (content.Created > options.LookbackDate || content.LastModified > options.LookbackDate)
+                if (content.Created >= options.MaxAgeDate || content.LastModified >= options.MaxAgeDate)
                 {
                     content.MapComponents(schemaMap);
 

--- a/cli/Squidex.CLI/Squidex.CLI.Core/Commands/Implementation/Sync/SyncOptions.cs
+++ b/cli/Squidex.CLI/Squidex.CLI.Core/Commands/Implementation/Sync/SyncOptions.cs
@@ -21,5 +21,5 @@ public sealed class SyncOptions
 
     public bool UpdateCurrentClient { get; set; }
 
-    public DateTimeOffset LookbackDate { get; set; }
+    public DateTimeOffset MaxAgeDate { get; set; }
 }

--- a/cli/Squidex.CLI/Squidex.CLI.Core/Commands/Implementation/Sync/SyncOptions.cs
+++ b/cli/Squidex.CLI/Squidex.CLI.Core/Commands/Implementation/Sync/SyncOptions.cs
@@ -20,4 +20,6 @@ public sealed class SyncOptions
     public bool Recreate { get; set; }
 
     public bool UpdateCurrentClient { get; set; }
+
+    public DateTimeOffset LookbackDate { get; set; }
 }

--- a/cli/Squidex.CLI/Squidex.CLI/Commands/App_Sync.cs
+++ b/cli/Squidex.CLI/Squidex.CLI/Commands/App_Sync.cs
@@ -168,15 +168,15 @@ public sealed partial class App
             [Option('t', "targets", Description = "The targets to sync, e.g. ‘sync out -t contents -t schemas’. Use 'sync targets' to view all targets.")]
             public string[] Targets { get; set; }
 
-            [Option("lookback-days", Description = "Content & assets created or last modified within days defined")]
-            public int? LookbackDays { get; set; }
+            [Option("max-age", Description = "Content & assets created or last modified within days defined")]
+            public int? MaxAge { get; set; }
 
             [Option("describe", Description = "Create a README.md file.")]
             public bool Describe { get; set; }
 
             public SyncOptions ToOptions()
             {
-                return new SyncOptions { Targets = Targets, LookbackDate = GetLookbackDate() };
+                return new SyncOptions { Targets = Targets, MaxAgeDate = GetMaxAgeDate() };
             }
 
             public sealed class Validator : AbstractValidator<OutArguments>
@@ -187,9 +187,9 @@ public sealed partial class App
                 }
             }
 
-            private DateTimeOffset GetLookbackDate()
+            private DateTimeOffset GetMaxAgeDate()
             {
-                return LookbackDays == null ? DateTimeOffset.MinValue : new DateTimeOffset(DateTime.Today.AddDays(-(int)LookbackDays));
+                return MaxAge == null ? DateTimeOffset.MinValue : new DateTimeOffset(DateTime.Today.AddDays(-(int)MaxAge));
             }
         }
 

--- a/cli/Squidex.CLI/Squidex.CLI/Commands/App_Sync.cs
+++ b/cli/Squidex.CLI/Squidex.CLI/Commands/App_Sync.cs
@@ -168,7 +168,7 @@ public sealed partial class App
             [Option('t', "targets", Description = "The targets to sync, e.g. ‘sync out -t contents -t schemas’. Use 'sync targets' to view all targets.")]
             public string[] Targets { get; set; }
 
-            [Option("max-age", Description = "Content & assets created or last modified within timeSpan defined")]
+            [Option("max-age", Description = "Content & assets created or last modified within time span defined.")]
             public TimeSpan? MaxAge { get; set; }
 
             [Option("describe", Description = "Create a README.md file.")]

--- a/cli/Squidex.CLI/Squidex.CLI/Commands/App_Sync.cs
+++ b/cli/Squidex.CLI/Squidex.CLI/Commands/App_Sync.cs
@@ -168,12 +168,15 @@ public sealed partial class App
             [Option('t', "targets", Description = "The targets to sync, e.g. ‘sync out -t contents -t schemas’. Use 'sync targets' to view all targets.")]
             public string[] Targets { get; set; }
 
+            [Option("lookback-days", Description = "Content & assets created or last modified within days defined")]
+            public int? LookbackDays { get; set; }
+
             [Option("describe", Description = "Create a README.md file.")]
             public bool Describe { get; set; }
 
             public SyncOptions ToOptions()
             {
-                return new SyncOptions { Targets = Targets };
+                return new SyncOptions { Targets = Targets, LookbackDate = GetLookbackDate() };
             }
 
             public sealed class Validator : AbstractValidator<OutArguments>
@@ -182,6 +185,11 @@ public sealed partial class App
                 {
                     RuleFor(x => x.Folder).NotEmpty();
                 }
+            }
+
+            private DateTimeOffset GetLookbackDate()
+            {
+                return LookbackDays == null ? DateTimeOffset.MinValue : new DateTimeOffset(DateTime.Today.AddDays(-(int)LookbackDays));
             }
         }
 

--- a/cli/Squidex.CLI/Squidex.CLI/Commands/App_Sync.cs
+++ b/cli/Squidex.CLI/Squidex.CLI/Commands/App_Sync.cs
@@ -168,8 +168,8 @@ public sealed partial class App
             [Option('t', "targets", Description = "The targets to sync, e.g. ‘sync out -t contents -t schemas’. Use 'sync targets' to view all targets.")]
             public string[] Targets { get; set; }
 
-            [Option("max-age", Description = "Content & assets created or last modified within days defined")]
-            public int? MaxAge { get; set; }
+            [Option("max-age", Description = "Content & assets created or last modified within timeSpan defined")]
+            public TimeSpan? MaxAge { get; set; }
 
             [Option("describe", Description = "Create a README.md file.")]
             public bool Describe { get; set; }
@@ -189,7 +189,7 @@ public sealed partial class App
 
             private DateTimeOffset GetMaxAgeDate()
             {
-                return MaxAge == null ? DateTimeOffset.MinValue : new DateTimeOffset(DateTime.Today.AddDays(-(int)MaxAge));
+                return MaxAge == null ? DateTimeOffset.MinValue : new DateTimeOffset(DateTime.Today.Add(-(TimeSpan)MaxAge));
             }
         }
 


### PR DESCRIPTION
For apps with large amounts of assets or content, the ability to sync a smaller portion of data will improve overall performance of sync operations, while still syncing required updates.

**Example**
``sq config use app-1``
``sq sync out app-sync-7-days --lookback-days 7``
``sq config use app-2``
``sq sync in app-sync-7-days``

This will give the past 7 days of created/update content and assets.  Other sync items such as schemas, workflows, etc will remain GetAll.