### PR TITLE
Use the delimiter argument for exporting CSV files.

### DIFF
--- a/cli/Squidex.CLI/Squidex.CLI/Commands/App_Contents.cs
+++ b/cli/Squidex.CLI/Squidex.CLI/Commands/App_Contents.cs
@@ -247,7 +247,7 @@ public partial class App
                     {
                         var csvOptions = new CsvConfiguration(CultureInfo.InvariantCulture)
                         {
-                            Delimiter = ";"
+                            Delimiter = arguments.Delimiter
                         };
 
                         await using (var writer = new CsvWriter(streamWriter, csvOptions))


### PR DESCRIPTION
Bug in export -- delimiter argument isn't being used for export.

Thanks for all your awesome efforts, Sebastian.