### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.0.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
         
     steps:
-    - uses: actions/checkout@v3.4.0
+    - uses: actions/checkout@v4.0.0
 
     - name: setup zip
       uses: montudor/action-zip@v1.0.0

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
         
     steps:
-    - uses: actions/checkout@v3.4.0
+    - uses: actions/checkout@v4.0.0
  
     - name: setup dotnet
       uses: actions/setup-dotnet@v3.0.3


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.0.0](https://github.com/actions/checkout/releases/tag/v4.0.0)** on 2023-09-04T12:22:57Z
