### PR TITLE
+ [Editors] vite config for base url

### DIFF
--- a/editors/markdown/README.md
+++ b/editors/markdown/README.md
@@ -15,6 +15,8 @@ npm i
 npm run build
 ```
 
+If you want to run the editor from a subfolder of your domain instead of the domains root you have to configure your base (url) inside the vite.config.js before running the build.
+
 The build process will put all files to the dist folders. Put these files to a web server and use the URL to your webserver in the Squidex UI, for example:
 
 ```

--- a/editors/markdown/README.md
+++ b/editors/markdown/README.md
@@ -15,7 +15,7 @@ npm i
 npm run build
 ```
 
-If you want to run the editor from a subfolder of your domain instead of the domains root you have to configure your base (url) inside the vite.config.js before running the build.
+If you want to run the editor from a subfolder of your domain instead of the domains root you have to configure your base (url) inside the `vite.config.js` before running the build or you can pass a base path via the build command inside the `package.json` by appending `--base=/your/path/here` after the call to Vite.
 
 The build process will put all files to the dist folders. Put these files to a web server and use the URL to your webserver in the Squidex UI, for example:
 

--- a/editors/markdown/vite.config.js
+++ b/editors/markdown/vite.config.js
@@ -1,0 +1,6 @@
+// vite.config.js
+export default {
+  // base url [prefix] (you need to configure this, if you want to run the editor out of a subdirectory of the domain)
+  // either add the full url or the directory path like e.g. '/squidex-samples/editors/richtext'
+  base: "/",
+};

--- a/editors/richtext/README.md
+++ b/editors/richtext/README.md
@@ -15,6 +15,8 @@ npm i
 npm run build
 ```
 
+If you want to run the editor from a subfolder of your domain instead of the domains root you have to configure your base (url) inside the vite.config.js before running the build.
+
 The build process will put all files to the dist folders. Put these files to a web server and use the URL to your webserver in the Squidex UI, for example:
 
 ```

--- a/editors/richtext/README.md
+++ b/editors/richtext/README.md
@@ -15,7 +15,7 @@ npm i
 npm run build
 ```
 
-If you want to run the editor from a subfolder of your domain instead of the domains root you have to configure your base (url) inside the vite.config.js before running the build.
+If you want to run the editor from a subfolder of your domain instead of the domains root you have to configure your base (url) inside the `vite.config.js` before running the build or you can pass a base path via the build command inside the `package.json` by appending `--base=/your/path/here` after the call to Vite.
 
 The build process will put all files to the dist folders. Put these files to a web server and use the URL to your webserver in the Squidex UI, for example:
 

--- a/editors/richtext/vite.config.js
+++ b/editors/richtext/vite.config.js
@@ -1,0 +1,6 @@
+// vite.config.js
+export default {
+    // base url [prefix] (you need to configure this, if you want to run the editor out of a subdirectory of the domain)
+    // either add the full url or the directory path like e.g. '/squidex-samples/editors/richtext'
+    base: "/",
+};


### PR DESCRIPTION
+ [MarkdownEditor] vite config for base url
+ [RichtextEditor] vite config for base url

Hi Sebastian,

I just added a vite config so one can create the output build for the editors to be able to run it in a subdirectory of a domain instead of just in the domain root.