### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/editors.yml
+++ b/.github/workflows/editors.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v4.1.1
   
     - name: Setup Node.js environment
-      uses: actions/setup-node@v3.8.1
+      uses: actions/setup-node@v4.0.0
 
     - name: Move Files
       run: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.0](https://github.com/actions/setup-node/releases/tag/v4.0.0)** on 2023-10-23T14:55:24Z
