### PR TITLE
Corrected "schemas" typos.

### DIFF
--- a/cli/Squidex.CLI/Squidex.CLI/Commands/App_Apps.cs
+++ b/cli/Squidex.CLI/Squidex.CLI/Commands/App_Apps.cs
@@ -22,7 +22,7 @@ public partial class App
     [Subcommand]
     public sealed class Apps(IConfigurationService configuration, ILogger log)
     {
-        [Command("list", Description = "List all schemas.")]
+        [Command("list", Description = "List all apps.")]
         public async Task List(ListArguments arguments)
         {
             var session = configuration.StartSession(arguments.App);

--- a/cli/Squidex.CLI/Squidex.CLI/Commands/App_Indexes.cs
+++ b/cli/Squidex.CLI/Squidex.CLI/Commands/App_Indexes.cs
@@ -20,11 +20,11 @@ namespace Squidex.CLI.Commands;
 
 public sealed partial class App
 {
-    [Command("indexes", Description = "Manage schemas.")]
+    [Command("indexes", Description = "Manage indexes.")]
     [Subcommand]
     public sealed partial class Indexes(IConfigurationService configuration, ILogger log)
     {
-        [Command("list", Description = "List all schemas.")]
+        [Command("list", Description = "List all indexes.")]
         public async Task List(ListArguments arguments)
         {
             var session = configuration.StartSession(arguments.App);


### PR DESCRIPTION
Related to support case https://support.squidex.io/t/squidex-cli-sq-indexes/5879.

Code changes to correct the typos for Indexes module.