### PR TITLE
Corrected apps delete function.

### DIFF
--- a/cli/Squidex.CLI/Squidex.CLI/Commands/App_Apps.cs
+++ b/cli/Squidex.CLI/Squidex.CLI/Commands/App_Apps.cs
@@ -75,14 +75,9 @@ public partial class App
 
             var name = arguments.App;
 
-            if (string.IsNullOrWhiteSpace(name))
+            if (!string.Equals(session.App, arguments.Confirm, StringComparison.Ordinal))
             {
-                name = session.App;
-            }
-
-            if (!string.Equals(name, arguments.Confirm, StringComparison.Ordinal))
-            {
-                throw new CLIException("Confirmed app name does not match.");
+                throw new CLIException("Confirmed app name does not match with the session app name.");
             }
 
             await session.Client.Apps.DeleteAppAsync();

--- a/cli/Squidex.CLI/Squidex.CLI/Commands/App_Apps.cs
+++ b/cli/Squidex.CLI/Squidex.CLI/Commands/App_Apps.cs
@@ -22,7 +22,7 @@ public partial class App
     [Subcommand]
     public sealed class Apps(IConfigurationService configuration, ILogger log)
     {
-        [Command("list", Description = "List all schemas.")]
+        [Command("list", Description = "List all apps.")]
         public async Task List(ListArguments arguments)
         {
             var session = configuration.StartSession(arguments.App);

--- a/cli/Squidex.CLI/Squidex.CLI/Commands/App_Indexes.cs
+++ b/cli/Squidex.CLI/Squidex.CLI/Commands/App_Indexes.cs
@@ -20,11 +20,11 @@ namespace Squidex.CLI.Commands;
 
 public sealed partial class App
 {
-    [Command("indexes", Description = "Manage schemas.")]
+    [Command("indexes", Description = "Manage indexes.")]
     [Subcommand]
     public sealed partial class Indexes(IConfigurationService configuration, ILogger log)
     {
-        [Command("list", Description = "List all schemas.")]
+        [Command("list", Description = "List all indexes.")]
         public async Task List(ListArguments arguments)
         {
             var session = configuration.StartSession(arguments.App);


### PR DESCRIPTION
Related to support case https://support.squidex.io/t/squide-cli-sq-apps-list-and-delete-issue/5889/9.

As discussed
> The confirm does not compare if the name is the same as the selected app, but uses the --name flag instead.