### PR TITLE
Update CachingAuthenticator.cs default cache expiration time to 29days

### DIFF
--- a/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/Configuration/CachingAuthenticator.cs
+++ b/csharp/Squidex.ClientLibrary/Squidex.ClientLibrary/Configuration/CachingAuthenticator.cs
@@ -41,7 +41,7 @@ public class CachingAuthenticator : IAuthenticator
         {
             result = await authenticator.GetBearerTokenAsync(appName, ct);
 
-            cache.Set(appName, result, TimeSpan.FromDays(50));
+            cache.Set(appName, result, TimeSpan.FromDays(29));
         }
 
         return result;


### PR DESCRIPTION
Base on: https://support.squidex.io/t/unauthorized-401-token-expired/1299 token is valid for 30days but cache is set to 50.

Ideal solution would be actually passing value based on actual validity, but i think this is good enough (as nobody cares for 5 years).